### PR TITLE
Fixed callback target

### DIFF
--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -24,7 +24,7 @@ module.exports = class ToolBarButtonView extends View
         if typeof options.callback is 'string'
           atom.commands.dispatch @getPreviouslyFocusedElement(), options.callback
         else
-          options.callback(options.data)
+          options.callback(options.data, @getPreviouslyFocusedElement())
 
     @on 'mouseover', =>
       @storeFocusedElement()

--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-{View} = require 'space-pen'
+{$, View} = require 'space-pen'
 
 module.exports = class ToolBarButtonView extends View
   @content: ->
@@ -22,9 +22,12 @@ module.exports = class ToolBarButtonView extends View
     @on 'click', =>
       if not @hasClass 'disabled'
         if typeof options.callback is 'string'
-          atom.commands.dispatch atom.views.getView(atom.workspace.getActiveTextEditor()), options.callback
+          atom.commands.dispatch @getPreviouslyFocusedElement(), options.callback
         else
           options.callback(options.data)
+
+    @on 'mouseover', =>
+      @storeFocusedElement()
 
   setEnabled: (enabled) ->
     if enabled
@@ -34,3 +37,12 @@ module.exports = class ToolBarButtonView extends View
 
   destroy: ->
     @subscriptions.dispose()
+
+  getPreviouslyFocusedElement: () ->
+    if @previouslyFocusedElement[0] and @previouslyFocusedElement[0] isnt document.body
+      @eventElement = @previouslyFocusedElement[0]
+    else
+      @eventElement = atom.views.getView(atom.workspace)
+
+  storeFocusedElement: ->
+    @previouslyFocusedElement = $(document.activeElement)

--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -45,4 +45,6 @@ module.exports = class ToolBarButtonView extends View
       @eventElement = atom.views.getView(atom.workspace)
 
   storeFocusedElement: ->
-    @previouslyFocusedElement = $(document.activeElement)
+    activeElement = $(document.activeElement)
+    if !activeElement.hasClass 'tool-bar-btn'
+      @previouslyFocusedElement = activeElement

--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-{$, View} = require 'space-pen'
+{View} = require 'space-pen'
 
 module.exports = class ToolBarButtonView extends View
   @content: ->
@@ -39,12 +39,11 @@ module.exports = class ToolBarButtonView extends View
     @subscriptions.dispose()
 
   getPreviouslyFocusedElement: () ->
-    if @previouslyFocusedElement[0] and @previouslyFocusedElement[0] isnt document.body
-      @eventElement = @previouslyFocusedElement[0]
+    if @previouslyFocusedElement and @previouslyFocusedElement.nodeName isnt 'BODY'
+      @eventElement = @previouslyFocusedElement
     else
       @eventElement = atom.views.getView(atom.workspace)
 
   storeFocusedElement: ->
-    activeElement = $(document.activeElement)
-    if !activeElement.hasClass 'tool-bar-btn'
-      @previouslyFocusedElement = activeElement
+    if not document.activeElement.classList.contains 'tool-bar-btn'
+      @previouslyFocusedElement = document.activeElement

--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -22,7 +22,7 @@ module.exports = class ToolBarButtonView extends View
     @on 'click', =>
       if not @hasClass 'disabled'
         if typeof options.callback is 'string'
-          atom.commands.dispatch document.activeElement, options.callback
+          atom.commands.dispatch atom.views.getView(atom.workspace.getActiveTextEditor()), options.callback
         else
           options.callback(options.data)
 


### PR DESCRIPTION
Current `dispatch` target `document.activeElement` isn't work on some commands.
So I changed it :)

I tested this `target` with any commands.
For example, `pane:split-right`, `bookmarks:toggle-bookmark` and more.
And it worked.