### PR TITLE
Buttons overflow/wrap. Fixes #38

### DIFF
--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -8,6 +8,9 @@
   background-color: @base-background-color;
   border: 1px solid @base-border-color;
   color: @text-color;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 
   button.tool-bar-btn {
     background-color: @base-background-color;
@@ -23,8 +26,8 @@
     }
     &:focus,
     &:hover {
-      outline: none;
       border-color: @button-border-color;
+      outline: none;
     }
   }
 
@@ -66,12 +69,12 @@
     line-height: @size;
 
     &.tool-bar-horizontal {
-      height: @size + (@button-border-size * 3)+ (@button-margin-size * 2);
+      flex-direction: row;
       width: 100%;
     }
     &.tool-bar-vertical {
+      flex-direction: column;
       height: 100%;
-      width: @size + (@button-border-size * 3) + (@button-margin-size * 2);
     }
 
     .tool-bar-btn {


### PR DESCRIPTION
Fixes: https://github.com/suda/tool-bar/issues/38

This PR will wrap buttons to a new row on horizontal toolbars and scroll the toolbar on vertical toolbars.

![atom wrap horzontal](https://cloud.githubusercontent.com/assets/55841/7811456/17c51f6e-03ab-11e5-90cf-a327947c52fe.png)

![toolbar overflow vertical](https://cloud.githubusercontent.com/assets/55841/7537286/055207d2-f598-11e4-994e-2dbd82c8ec98.png)

Big thanks to @simurai for his help :clap: 