### PR TITLE
Show gutter shadow on vertical scrolling

### DIFF
--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-{$, View} = require 'space-pen'
+{View} = require 'space-pen'
 _ = require 'underscore-plus'
 
 module.exports = class ToolBarView extends View
@@ -58,8 +58,8 @@ module.exports = class ToolBarView extends View
     if atom.config.get 'tool-bar.visible'
       @show()
 
-    @on 'scroll', @drawGutter
-    $(window).on 'resize', @drawGutter
+    @.element.addEventListener 'scroll', @drawGutter
+    window.addEventListener 'resize', @drawGutter
 
   serialize: ->
 
@@ -67,7 +67,7 @@ module.exports = class ToolBarView extends View
     @subscriptions.dispose()
     @detach() if @panel?
     @panel.destroy() if @panel?
-    $(window).off 'resize', @drawGutter
+    window.removeEventListener 'resize', @drawGutter
 
   updateSize: (size) ->
     @removeClass 'tool-bar-16px tool-bar-24px tool-bar-32px'

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -91,10 +91,10 @@
         z-index: 1;
       }
       &.gutter-top::before {
-        box-shadow: inset 0px 10px 20px -10px rgba(50, 50, 50, 0.5);
+        box-shadow: inset 0px 20px 25px -20px rgb(0, 0, 0);
       }
       &.gutter-bottom::after {
-        box-shadow: inset 0px -10px 20px -10px rgba(50, 50, 50, 0.5);
+        box-shadow: inset 0px -20px 25px -20px rgb(0, 0, 0);
       }
     }
 

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -78,27 +78,23 @@
       &::-webkit-scrollbar {
         display: none;
       }
-      &.gutter-top::before {
-        box-shadow: inset 0px 10px 20px -10px rgba(50, 50, 50, 0.5);
+
+      &.gutter-top::before,
+      &.gutter-bottom::after {
         content: "";
+        height: 100%;
+        left: 0;
+        pointer-events: none;
         position: absolute;
         top: 0;
-        left: 0;
-        height: 100%;
         width: 100%;
         z-index: 1;
-        pointer-events: none;
+      }
+      &.gutter-top::before {
+        box-shadow: inset 0px 10px 20px -10px rgba(50, 50, 50, 0.5);
       }
       &.gutter-bottom::after {
         box-shadow: inset 0px -10px 20px -10px rgba(50, 50, 50, 0.5);
-        content: "";
-        position: absolute;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
-        z-index: 1;
-        pointer-events: none;
       }
     }
 

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -78,6 +78,28 @@
       &::-webkit-scrollbar {
         display: none;
       }
+      &.gutter-top::before {
+        box-shadow: inset 0px 10px 20px -10px rgba(50, 50, 50, 0.5);
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        z-index: 1;
+        pointer-events: none;
+      }
+      &.gutter-bottom::after {
+        box-shadow: inset 0px -10px 20px -10px rgba(50, 50, 50, 0.5);
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        z-index: 1;
+        pointer-events: none;
+      }
     }
 
     .tool-bar-btn {


### PR DESCRIPTION
This PR adds gutter shadow for vertical tool-bars when it overflows.

Ref: https://github.com/suda/tool-bar/issues/38

| Bottom | Top | Bottom & Top | Dark theme |
| --- | ---- | ---- | ---- |
| ![2015-05-31 23_31_11-tool-bar-view coffee - atom](https://cloud.githubusercontent.com/assets/55841/7904011/39a5fec8-07ed-11e5-802e-67bd12e88269.png) | ![2015-05-31 23_33_36-tool-bar-view coffee - atom](https://cloud.githubusercontent.com/assets/55841/7904022/7fa59302-07ed-11e5-8f90-b49a753d6e46.png) | ![theme light](https://cloud.githubusercontent.com/assets/55841/7946765/ded8b7c8-0978-11e5-9e6a-3bdd5cbd2741.png) | ![theme dark](https://cloud.githubusercontent.com/assets/55841/7946769/e60ddd34-0978-11e5-9efb-5b94f800fca4.png)

This is just an idea :bulb: taken from the [Gutter Shadow](https://github.com/dsandstrom/atom-gutter-shadow) package, which I liked very much.

* [x] I have to test this more and with different themes.