### PR TITLE
Change tooltip placement based on toolbar position

### DIFF
--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -12,17 +12,9 @@ module.exports = class ToolBarButtonView extends View
 
     if options.tooltip
       @prop 'title', options.tooltip
-      toolbarPosition = atom.config.get('tool-bar.position')
-      tooltipPlacement = (toolbarPosition is "Top")    and "bottom" or
-                         (toolbarPosition is "Right")  and "left"   or
-                         (toolbarPosition is "Bottom") and "top"    or
-                         (toolbarPosition is "Left")   and "right"
-      @subscriptions.add atom.tooltips.add(
-        this,
-        {
-          title: options.tooltip
-          placement: tooltipPlacement
-        }
+      @subscriptions.add atom.tooltips.add(this,
+        title: options.tooltip
+        placement: @getTooltipPlacement
       )
 
     if options.iconset
@@ -58,3 +50,11 @@ module.exports = class ToolBarButtonView extends View
   storeFocusedElement: ->
     if not document.activeElement.classList.contains 'tool-bar-btn'
       @previouslyFocusedElement = document.activeElement
+
+  getTooltipPlacement: ->
+    toolbarPosition = atom.config.get 'tool-bar.position'
+    return toolbarPosition is "Top"    and "bottom" or
+           toolbarPosition is "Right"  and "left"   or
+           toolbarPosition is "Bottom" and "top"    or
+           toolbarPosition is "Left"   and "right"
+

--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -12,7 +12,18 @@ module.exports = class ToolBarButtonView extends View
 
     if options.tooltip
       @prop 'title', options.tooltip
-      @subscriptions.add atom.tooltips.add(this, title: options.tooltip)
+      toolbarPosition = atom.config.get('tool-bar.position')
+      tooltipPlacement = (toolbarPosition is "Top")    and "bottom" or
+                         (toolbarPosition is "Right")  and "left"   or
+                         (toolbarPosition is "Bottom") and "top"    or
+                         (toolbarPosition is "Left")   and "right"
+      @subscriptions.add atom.tooltips.add(
+        this,
+        {
+          title: options.tooltip
+          placement: tooltipPlacement
+        }
+      )
 
     if options.iconset
       @addClass "#{options.iconset} #{options.iconset}-#{options.icon}"


### PR DESCRIPTION
Continuing from https://github.com/suda/tool-bar/issues/68, this changes the tooltip's placement based on the toolbar's position.

The tooltip's position is opposite the toolbar, e.g. if the toolbar is on the left, the tooltip is on the right.