### PR TITLE
Better support for Isotope UI theme

### DIFF
--- a/styles/theme-isotope-light-ui.less
+++ b/styles/theme-isotope-light-ui.less
@@ -1,0 +1,16 @@
+.theme-isotope-light-ui {
+  .tool-bar {
+    border: none;
+    background: fadeout(@base-background-color, 100%);
+
+    button.tool-bar-btn {
+      background: inherit;
+      border-color: fadeout(@base-background-color, 100%);
+      &:focus,
+      &:hover {
+        border-color: fadeout(@base-background-color, 100%);
+        background: darken(fadeout(@base-background-color, 80%), 75%);
+      }
+    }
+  }
+}

--- a/styles/theme-isotope-ui.less
+++ b/styles/theme-isotope-ui.less
@@ -1,0 +1,16 @@
+.theme-isotope-ui {
+  .tool-bar {
+    border: none;
+    background: fadeout(@base-background-color, 100%);
+    
+    button.tool-bar-btn {
+      background: inherit;
+      border-color: fadeout(@base-background-color, 100%);
+      &:focus,
+      &:hover {
+        border-color: fadeout(@base-background-color, 100%);
+        background: lighten(fadeout(@base-background-color, 80%), 25%);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #75 

Better support for Isotope UI themes:
* [Isotope UI theme](https://github.com/braver/isotope-ui)
* [Isotope Light UI theme](https://github.com/braver/isotope-light-ui)

Thanks to @k2b6s9j for reporting and providing the style changes.