### PR TITLE
Add icon resizing triggered by window resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ This package provides extensible tool bar for Atom.
 * Big *(24px)*
 * Large *(32px)*
 
+### Automatic Icon Resizing
+ * Enabled *(Icons resize with the window to keep all icons visible, when possible)*
+ * Disabled *(Icons always remain at the set size)*
+
 ### Visiblity
 
 * Visible

--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -61,6 +61,9 @@ module.exports = class ToolBarView extends View
     @.element.addEventListener 'scroll', @drawGutter
     window.addEventListener 'resize', @drawGutter
 
+    if atom.config.get 'tool-bar.automaticallyResizeIcons'
+      window.addEventListener 'resize', @updateAutoSize
+
   serialize: ->
 
   destroy: ->
@@ -68,6 +71,15 @@ module.exports = class ToolBarView extends View
     @detach() if @panel?
     @panel.destroy() if @panel?
     window.removeEventListener 'resize', @drawGutter
+
+  updateAutoSize: =>
+    idealSize = @height() / @items.length / 1.5
+    autoSize = 16
+    if idealSize >= 32
+      autoSize = 32
+    else if idealSize >= 24
+      autoSize = 24
+    @updateSize "#{autoSize}px"
 
   updateSize: (size) ->
     @removeClass 'tool-bar-16px tool-bar-24px tool-bar-32px'

--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -64,6 +64,14 @@ module.exports = class ToolBarView extends View
     if atom.config.get 'tool-bar.automaticallyResizeIcons'
       window.addEventListener 'resize', @updateAutoSize
 
+    atom.config.observe 'tool-bar.automaticallyResizeIcons', (nowSet) =>
+      if nowSet
+        @updateAutoSize
+        window.addEventListener 'resize', @updateAutoSize
+      else
+        @updateSize atom.config.get 'tool-bar.iconSize'
+        window.removeEventListener 'resize', @updateAutoSize
+
   serialize: ->
 
   destroy: ->

--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -71,6 +71,7 @@ module.exports = class ToolBarView extends View
     @detach() if @panel?
     @panel.destroy() if @panel?
     window.removeEventListener 'resize', @drawGutter
+    window.removeEventListener 'resize', @updateAutoSize
 
   updateAutoSize: =>
     idealSize = @height() / @items.length / 1.5

--- a/lib/tool-bar.coffee
+++ b/lib/tool-bar.coffee
@@ -25,6 +25,9 @@ module.exports =
       type: 'string'
       default: '24px'
       enum: ['16px', '24px', '32px']
+    automaticallyResizeIcons:
+      type: 'boolean'
+      default: false
 
   provideToolBar: ->
     (group) => new ToolBarManager group, @toolBar


### PR DESCRIPTION
I built this for myself, but figured I'd push it back as a non-breaking change that others might find useful.

I was using atom both on my laptop and on large monitors and the most comfortable icon size was 16px in the former case and 32px in the latter.  When Automatically Resize Icons is enabled, the icon size will vary between the three options, such that it selects the largest size that fits all icons on the screen.  Also helpful if I have a few small windows open and don't want the tool bar taking up so much of the smaller space.