### PR TITLE
Remove top-level menu shortcut to fix alpha sorting

### DIFF
--- a/menus/tool-bar.cson
+++ b/menus/tool-bar.cson
@@ -3,7 +3,7 @@ menu: [
     label: 'Packages'
     submenu: [
       {
-        label: '&Tool Bar'
+        label: 'Tool Bar'
         submenu: [
           { label: '&Toggle', command: 'tool-bar:toggle' }
           {


### PR DESCRIPTION
Fixes #97.

Before:
<img width="226" alt="before" src="https://cloud.githubusercontent.com/assets/830952/12428179/09fea604-be98-11e5-8c23-9722d11b2230.png">


After:
<img width="231" alt="after" src="https://cloud.githubusercontent.com/assets/830952/12428181/0bfd8312-be98-11e5-8e82-3f468037ea69.png">
