### PR TITLE
Fix memory leaks and add onDidDestroy (Fixes #96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ consumeToolBar: (toolBar) ->
     icon: 'octoface'
     callback: 'application:about'
     priority: 10
+
+  # Cleaning up when tool bar is deactivated
+  @toolBar.onDidDestroy ->
+    @toolBar = null
+    # Teardown any stateful code that depends on tool bar ...
 ```
 
 The method `addButton` requires an object with at least the properties `icon` and `callback`.
@@ -132,6 +137,8 @@ The remaining properties `tooltip` (default is no tooltip), `iconset` (defaults 
 The method `addSpacer` has only one optional property `priority` (defaults `50`).
 
 Use the method `removeItems` to remove the buttons added by your package. This is particulair useful in your package `deactivate` method, but can be used at any time.
+
+The `onDidDestroy` method takes a function that will be called when the `tool-bar` package is destroyed. This is useful if your package needs to do some cleanup when the `tool-bar` is deactivated but your package continues running.
 
 ## Supported icon sets
 

--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -42,6 +42,8 @@ module.exports = class ToolBarButtonView extends View
 
   destroy: ->
     @subscriptions.dispose()
+    @subscriptions = null
+    @remove()
 
   getPreviouslyFocusedElement: ->
     if @previouslyFocusedElement and @previouslyFocusedElement.nodeName isnt 'BODY'

--- a/lib/tool-bar-manager.coffee
+++ b/lib/tool-bar-manager.coffee
@@ -23,3 +23,6 @@ module.exports = class ToolBarManager
       item.group is @group
     .forEach (item) =>
       @toolBar.removeItem item
+
+  onDidDestroy: (callback) ->
+    @toolBar.emitter.on 'did-destroy', callback

--- a/lib/tool-bar-manager.coffee
+++ b/lib/tool-bar-manager.coffee
@@ -14,11 +14,12 @@ module.exports = class ToolBarManager
     spacer = $$ -> @hr class: 'tool-bar-spacer'
     spacer.priority = options?.priority
     spacer.group = @group
+    spacer.destroy = -> spacer.remove()
     @toolBar.addItem spacer
     spacer
 
   removeItems: ->
-    items = @toolBar.items.filter (item) =>
+    @toolBar.items?.filter (item) =>
       item.group is @group
-    items.forEach (item) =>
+    .forEach (item) =>
       @toolBar.removeItem item

--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable} = require 'atom'
+{CompositeDisposable, Emitter} = require 'atom'
 {View} = require 'space-pen'
 _ = require 'underscore-plus'
 
@@ -27,6 +27,7 @@ module.exports = class ToolBarView extends View
 
   initialize: ->
     @items = []
+    @emitter = new Emitter
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace', 'tool-bar:toggle', =>
       @toggle()
@@ -70,6 +71,10 @@ module.exports = class ToolBarView extends View
     @hide()
     @remove()
     window.removeEventListener 'resize', @drawGutter
+
+    @emitter.emit 'did-destroy'
+    @emitter.dispose()
+    @emitter = null
 
   updateSize: (size) ->
     @removeClass 'tool-bar-12px tool-bar-16px tool-bar-24px tool-bar-32px'

--- a/lib/tool-bar.coffee
+++ b/lib/tool-bar.coffee
@@ -10,6 +10,7 @@ module.exports =
 
   deactivate: ->
     @toolBar.destroy()
+    @toolBar = null
 
   serialize: ->
 

--- a/spec/tool-bar-spec.coffee
+++ b/spec/tool-bar-spec.coffee
@@ -18,6 +18,11 @@ describe 'Tool Bar package', ->
     it 'removes the tool bar view', ->
       atom.packages.deactivatePackage('tool-bar')
       expect(workspaceElement.querySelector('.tool-bar')).toBeNull()
+    it 'notifies on destroy', ->
+      toolBarAPI = toolBarService('specs-tool-bar')
+      toolBarAPI.onDidDestroy spy = jasmine.createSpy()
+      atom.packages.deactivatePackage('tool-bar')
+      expect(spy).toHaveBeenCalled()
 
   describe 'provides a service API', ->
     it 'for others to use', ->


### PR DESCRIPTION
The first part of this PR fixes a few memory leaks around DOM event handlers and disposing of subscriptions.

The second part of this PR adds a for consumers to do cleanup when `tool-bar` is deactivated (e.g. during an upgrade).