### PR TITLE
Callback modifiers. Closes #44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## vNext
 * Fix memory leaks and add `onDidDestroy`. Fixes #96 (by [@zertosh](https://github.com/zertosh))
 * Added support for Material Design Icons. Closes #92 (by [@JamesCoyle](https://github.com/JamesCoyle))
+* Added support for callback modifiers. Closes #44
 * Updated Font Awesome 4.5.0
 * Updated IcoMoon
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ consumeToolBar: (toolBar) ->
     tooltip: 'Show Alert'
     data: 'foo'
 
+  # Callback with modifiers
+  @toolBar.addButton
+    icon: 'octoface',
+    callback:
+      '': 'application:cmd-1'  # Without modifiers is default action
+      'alt': 'application:cmd-2'
+      'ctrl': 'application:cmd-3'
+      'shift': (data) -> console.log data  # With function callback
+      'alt+shift': 'application:cmd-5'  # Multiple modifiers
+      'alt+ctrl+shift': 'application:cmd-6'  # All modifiers      
+    data: 'foo'
+
   # Adding spacer and button at the beginning of the tool bar
   @toolBar.addSpacer priority: 10
   @toolBar.addButton
@@ -129,13 +141,13 @@ consumeToolBar: (toolBar) ->
     # Teardown any stateful code that depends on tool bar ...
 ```
 
-The method `addButton` requires an object with at least the properties `icon` and `callback`.
+The method `addButton` requires an object with at least the properties `icon` and `callback`. The `icon` can be any icon from the `iconset`. The `callback` must be an Atom command string, an custom callback function or an object where the keys are key modifiers (`alt`, `ctrl` or `shift`) and the values are commands or custom function.
 
 The remaining properties `tooltip` (default is no tooltip), `iconset` (defaults `Octicons`), `data` and `priority` (defaults `50`) are optional.
 
 The method `addSpacer` has only one optional property `priority` (defaults `50`).
 
-Use the method `removeItems` to remove the buttons added by your package. This is particulair useful in your package `deactivate` method, but can be used at any time.
+Use the method `removeItems` to remove the buttons added by your package. This is particular useful in your package `deactivate` method, but can be used at any time.
 
 The `onDidDestroy` method takes a function that will be called when the `tool-bar` package is destroyed. This is useful if your package needs to do some cleanup when the `tool-bar` is deactivated but your package continues running.
 

--- a/spec/tool-bar-spec.coffee
+++ b/spec/tool-bar-spec.coffee
@@ -6,6 +6,12 @@ describe 'Tool Bar package', ->
       .charCodeAt(1)
       .toString(16)
       .toLowerCase()
+  buildClickEvent = ({altKey, ctrlKey, shiftKey}={}) ->
+    event = new MouseEvent('click')
+    Object.defineProperty(event, 'altKey', get: -> altKey) if altKey?
+    Object.defineProperty(event, 'ctrlKey', get: -> ctrlKey) if ctrlKey?
+    Object.defineProperty(event, 'shiftKey', get: -> shiftKey) if shiftKey?
+    event
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
@@ -128,7 +134,6 @@ describe 'Tool Bar package', ->
         expect(toolBar.firstChild.classList.contains('disabled')).toBe(true)
 
       it 'clicking button with command callback', ->
-        spy = undefined
         button = toolBarAPI.addButton
           icon: 'octoface'
           callback: 'application:about'
@@ -137,15 +142,14 @@ describe 'Tool Bar package', ->
         toolBar.firstChild.click()
         expect(spy).toHaveBeenCalled()
         expect(spy.mostRecentCall.args[0].type).toEqual('application:about')
-      it 'clicking button with callback function', ->
-        spy = undefined
+      it 'clicking button with function callback', ->
         button = toolBarAPI.addButton
           icon: 'octoface'
           callback: spy = jasmine.createSpy()
         jasmine.attachToDOM(toolBar)
         toolBar.firstChild.click()
         expect(spy).toHaveBeenCalled()
-      it 'clicking button with callback function containing data', ->
+      it 'clicking button with function callback containing data', ->
         button = toolBarAPI.addButton
           icon: 'octoface'
           callback: spy = jasmine.createSpy()
@@ -163,6 +167,86 @@ describe 'Tool Bar package', ->
         toolBar.firstChild.focus()
         toolBar.firstChild.click()
         expect(document.activeElement).toBe(previouslyFocusedElement)
+
+      describe 'by clicking', ->
+        describe 'with modifiers', ->
+          describe 'and command callback', ->
+            spy = null
+            beforeEach ->
+              toolBarAPI.addButton
+                icon: 'octoface'
+                callback:
+                  '': 'tool-bar:modifier-default'
+                  'alt': 'tool-bar:modifier-alt'
+                  'ctrl': 'tool-bar:modifier-ctrl'
+                  'shift': 'tool-bar:modifier-shift'
+                  'shift+alt': 'tool-bar:modifier-shift-alt' # Shouldn't execute
+                  'alt+shift': 'tool-bar:modifier-alt-shift' # Last added, should execute
+                  'ctrl+shift': 'tool-bar:modifier-ctrl-shift'
+                  # 'alt+ctrl': 'tool-bar:modifier-alt-ctrl' # Undefined should return default
+                  'alt ctrl-shift': 'tool-bar:modifier-alt-ctrl-shift' # Use any seperator
+                jasmine.attachToDOM(toolBar)
+                atom.commands.onWillDispatch spy = jasmine.createSpy()
+            it 'works without modifiers', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent())
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-default')
+            it 'works with alt key', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent(altKey: true))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt')
+            it 'works with ctrl key', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent(ctrlKey: true))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-ctrl')
+            it 'works with shift key', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent(shiftKey: true))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-shift')
+            it 'works with alt & shift key', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent({altKey: true, shiftKey: true}))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-shift')
+            it 'works with ctrl & shift key', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent({ctrlKey: true, shiftKey: true}))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-ctrl-shift')
+            it 'works with alt & ctrl & shift key', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent({altKey: true, ctrlKey: true, shiftKey: true}))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-ctrl-shift')
+            it 'works when modifier callback isn\'t defined', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent({altKey: true, ctrlKey: true}))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-default')
+            it 'works with last defined modifiers when there are duplicates', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent({altKey: true, shiftKey: true}))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-shift')
+            it 'works with any seperator between modifiers', ->
+              toolBar.firstChild.dispatchEvent(buildClickEvent({altKey: true, ctrlKey: true, shiftKey: true}))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-ctrl-shift')
+          describe 'and function callback', ->
+            it 'executes', ->
+              button = toolBarAPI.addButton
+                icon: 'octoface'
+                callback:
+                  '': 'tool-bar:modifier-default'
+                  'alt': spy = jasmine.createSpy()
+              jasmine.attachToDOM(toolBar)
+              toolBar.firstChild.dispatchEvent(buildClickEvent(altKey: true))
+              expect(spy).toHaveBeenCalled()
+            it 'executes with data', ->
+              button = toolBarAPI.addButton
+                icon: 'octoface'
+                callback:
+                  '': 'tool-bar:modifier-default'
+                  'alt': spy = jasmine.createSpy()
+                data: 'foo'
+              toolBar.firstChild.dispatchEvent(buildClickEvent(altKey: true))
+              expect(spy).toHaveBeenCalled()
+              expect(spy.mostRecentCall.args[0]).toEqual('foo')
 
     describe 'which can add a spacer', ->
       [toolBar] = []


### PR DESCRIPTION
Make it possible to setup multiple modifiers for one button. With this code it's possible to execute another callback when you click the button while holding the <kbd>alt</kbd>, <kbd>ctrl</kbd> or <kbd>shift</kbd> button.

Closes https://github.com/suda/tool-bar/issues/44.

```coffeescript
@toolBar.addButton
  icon: 'octoface'
  callback: 
    '': 'application:cmd-1'  # Without modifiers is default action
    'alt': 'application:cmd-2'
    'ctrl': 'application:cmd-3'
    'shift': (data) -> console.log data  # With function callback
    'alt+shift': 'application:cmd-5'  # Multiple modifiers
    'alt+ctrl+shift': 'application:cmd-6'  # All modifiers
  data: 'Hello World'
```

When no modifier or non-defined modifier combination is pressed, the default callback (defined by the empty key) is executed.

@suda, @cakecatz, @Leonick what do you think so far?

TODO:

- [x] Specs
- [x] Documentation.
- [x] Allow callbacks too instead of only commands