### PR TITLE
Align items to the end

### DIFF
--- a/lib/tool-bar-button-view.coffee
+++ b/lib/tool-bar-button-view.coffee
@@ -11,6 +11,7 @@ module.exports = class ToolBarButtonView extends View
     @subscriptions = new CompositeDisposable
 
     @priority = options.priority
+    @addClass 'tool-bar-item-align-end' if @priority < 0
 
     if options.tooltip
       @prop 'title', options.tooltip

--- a/lib/tool-bar-manager.coffee
+++ b/lib/tool-bar-manager.coffee
@@ -13,6 +13,7 @@ module.exports = class ToolBarManager
   addSpacer: (options) ->
     spacer = $$ -> @hr class: 'tool-bar-spacer'
     spacer.priority = options?.priority
+    spacer.addClass 'tool-bar-item-align-end' if spacer.priority < 0
     spacer.group = @group
     spacer.destroy = -> spacer.remove()
     @toolBar.addItem spacer

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -54,6 +54,18 @@
     margin: 0 @button-margin-size + 3;
   }
 
+  &.tool-bar-horizontal {
+    .tool-bar-btn,
+    .tool-bar-spacer {
+      &.tool-bar-item-align-end {
+        order: 2;
+        &:first-child {
+          margin-left: auto;
+        }
+      }
+    }
+  }
+
   &.tool-bar-12px {
     .tool-bar-size(12px * 2);
   }

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -66,6 +66,18 @@
     }
   }
 
+  &.tool-bar-vertical {
+    .tool-bar-btn,
+    .tool-bar-spacer {
+      &.tool-bar-item-align-end {
+        order: 2;
+        &:first-child {
+          margin-top: auto;
+        }
+      }
+    }
+  }
+
   &.tool-bar-12px {
     .tool-bar-size(12px * 2);
   }


### PR DESCRIPTION
This is ~~a WIP **draft**~~ to align tool-bar items (button & spacer) to the end of the tool-bar. On the horizontal to the right, on the vertical to the bottom. Items can be aligned to the end by using a negative value of the `priority` property.

Tries to fix #93 

![tool-bar-btn-right](https://cloud.githubusercontent.com/assets/55841/12901735/7caef80e-cebd-11e5-8e2b-438925176d6f.png)

~~Am not sure if this is the way to go or use `addLeftTile` & `addRightTile` like the status-bar package. Need to do some more thinking and testing.~~

Code used for testing:
```coffee
    @toolBar.addButton
      icon: 'arrow-circle-o-right'
      callback: 'application:new-file'
      iconset: 'fa'
      priority: -50
    @toolBar.addButton
      icon: 'folder'
      callback: 'application:open-file'
      iconset: 'ion'
      priority: -51
    @toolBar.addSpacer
      priority: -52
    @toolBar.addButton
      icon: 'archive'
      callback: 'core:save'
      iconset: 'ion'
      priority: -53
```