### PR TITLE
Fix scrolling

### DIFF
--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -77,7 +77,6 @@
     }
     &.tool-bar-vertical {
       flex-direction: column;
-      height: 100%;
       overflow-x: auto;
       &::-webkit-scrollbar {
         display: none;
@@ -118,4 +117,9 @@
       width: @size - 4;
     }
   }
+}
+
+// Deprecated. Can be removed after Atom 1.6 is released
+.tool-bar-vertical {
+  height: 100%;
 }


### PR DESCRIPTION
Adding the header/footer panels https://github.com/atom/atom/pull/9274 to Atom's core breaks scrolling in tool-bar. It will probably land in Atom `1.6`. Plus tool-bar overlaps any other footer packages:

![screen shot 2016-02-09 at 5 09 34 pm](https://cloud.githubusercontent.com/assets/378023/12910717/3df78ec6-cf50-11e5-9b95-220b2cead1be.png)

Most packages aren't affected, but tool-bar's selector beats [core](https://github.com/atom/atom/blob/127e4dbae404257f14e8a050c44c56964902c8ac/static/panels.less#L64-L68) in specificity.

This PR fixes it by moving the `height: 100%;` to a less specific selector. `.tool-bar.tool-bar-16px.tool-bar-vertical` -> `.tool-bar-vertical`. Once `1.6` is out, it could also be removed.

![tool-bar](https://cloud.githubusercontent.com/assets/378023/12910803/f8f601c6-cf50-11e5-9039-82a6b29cd439.gif)