### PR TITLE
Increment priority by group

### DIFF
--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -7,7 +7,10 @@ module.exports = class ToolBarView extends View
     @div class: 'tool-bar'
 
   addItem: (newItem) ->
-    newItem.priority ?= @items[@items.length - 1]?.priority ? 50
+    lastItem = @items.filter((item) -> item.group isnt newItem.group)?.pop()
+    newItem.priority ?= lastItem?.priority + 1 ? 50
+    newItem.get(0).dataset.group = newItem.group if atom.devMode
+    newItem.get(0).dataset.priority = newItem.priority if atom.devMode
     nextItem = null
     for existingItem, index in @items
       if existingItem.priority > newItem.priority


### PR DESCRIPTION
This will fix random ordering buttons when no priority was specified.

The previous situation was that it copied the priority from the last button/spacer. This could be from the same group (thus package) or from an other group. Resulting in buttons with the same priority from multiple groups ordered by first come.

New situation is that it will increment the priority from the last appended button/spacer that isn't part of the current group, making sure that all button/spacer without priority are at least grouped together.

The real fix is of course just to give all buttons/spacers in your package an priority:

* [x] https://github.com/cakecatz/flex-toolbar/pull/56