### PR TITLE
:sparkles: Full width header & footer tool bar. Closes #91

### DIFF
--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -2,6 +2,8 @@
 {View} = require 'space-pen'
 _ = require 'underscore-plus'
 
+supportFullWidth = typeof atom.workspace.addHeaderPanel is 'function'
+
 module.exports = class ToolBarView extends View
   @content: ->
     @div class: 'tool-bar'
@@ -53,6 +55,10 @@ module.exports = class ToolBarView extends View
     @subscriptions.add atom.config.onDidChange 'tool-bar.position', ({newValue, oldValue}) =>
       @show() if atom.config.get 'tool-bar.visible'
 
+    if supportFullWidth
+      @subscriptions.add atom.config.onDidChange 'tool-bar.fullWidth', ({newValue, oldValue}) =>
+        @show() if atom.config.get 'tool-bar.visible'
+
     @subscriptions.add atom.config.onDidChange 'tool-bar.visible', ({newValue, oldValue}) =>
       if newValue then @show() else @hide()
 
@@ -85,11 +91,16 @@ module.exports = class ToolBarView extends View
 
   updatePosition: (position) ->
     @removeClass 'tool-bar-top tool-bar-right tool-bar-bottom tool-bar-left tool-bar-horizontal tool-bar-vertical'
+    fullWidth = supportFullWidth and atom.config.get 'tool-bar.fullWidth'
 
     switch position
-      when 'Top' then @panel = atom.workspace.addTopPanel item: this
+      when 'Top'
+        if fullWidth then @panel = atom.workspace.addHeaderPanel item: this
+        else @panel = atom.workspace.addTopPanel item: this
       when 'Right' then @panel = atom.workspace.addRightPanel item: this
-      when 'Bottom' then @panel = atom.workspace.addBottomPanel item: this
+      when 'Bottom'
+        if fullWidth then @panel = atom.workspace.addFooterPanel item: this
+        else @panel = atom.workspace.addBottomPanel item: this
       when 'Left' then @panel = atom.workspace.addLeftPanel item: this, priority: 50
     @addClass "tool-bar-#{position.toLowerCase()}"
 

--- a/lib/tool-bar.coffee
+++ b/lib/tool-bar.coffee
@@ -15,17 +15,31 @@ module.exports =
   serialize: ->
 
   config:
-    position:
-      type: 'string'
-      default: 'Top'
-      enum: ['Top', 'Right', 'Bottom', 'Left']
-    visible:
-      type: 'boolean'
-      default: true
-    iconSize:
-      type: 'string'
-      default: '24px'
-      enum: ['12px', '16px', '24px', '32px']
+    (->
+      config =
+        visible:
+          type: 'boolean'
+          default: true
+          order: 1
+        iconSize:
+          type: 'string'
+          default: '24px'
+          enum: ['12px', '16px', '24px', '32px']
+          order: 2
+        position:
+          type: 'string'
+          default: 'Top'
+          enum: ['Top', 'Right', 'Bottom', 'Left']
+          order: 3
+
+      if typeof atom.workspace.addHeaderPanel is 'function'
+        config.fullWidth =
+          type: 'boolean'
+          default: true
+          order: 4
+
+      config
+    )()
 
   provideToolBar: ->
     (group) => new ToolBarManager group, @toolBar

--- a/spec/tool-bar-spec.coffee
+++ b/spec/tool-bar-spec.coffee
@@ -12,6 +12,7 @@ describe 'Tool Bar package', ->
     Object.defineProperty(event, 'ctrlKey', get: -> ctrlKey) if ctrlKey?
     Object.defineProperty(event, 'shiftKey', get: -> shiftKey) if shiftKey?
     event
+  supportFullWidth = typeof atom.workspace.addHeaderPanel is 'function'
 
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
@@ -273,42 +274,81 @@ describe 'Tool Bar package', ->
       expect(workspaceElement.querySelectorAll('.tool-bar').length).toBe(1)
 
   describe 'when tool-bar position is changed', ->
-    [topPanelElement, rightPanelElement, bottomPanelElement, leftPanelElement] = []
+    [headerPanelElement, topPanelElement, rightPanelElement,
+     footerPanelElement, bottomPanelElement, leftPanelElement] = []
 
     beforeEach ->
+      headerPanelElement = atom.views.getView(atom.workspace.panelContainers.header)
       topPanelElement = atom.views.getView(atom.workspace.panelContainers.top)
       rightPanelElement = atom.views.getView(atom.workspace.panelContainers.right)
+      footerPanelElement = atom.views.getView(atom.workspace.panelContainers.footer)
       bottomPanelElement = atom.views.getView(atom.workspace.panelContainers.bottom)
       leftPanelElement = atom.views.getView(atom.workspace.panelContainers.left)
 
-    describe 'by triggering tool-bar:position-top', ->
-      it 'the tool bar view is added to top pane', ->
+    if supportFullWidth
+      describe 'by triggering tool-bar:position-top', ->
+        it 'adds the tool bar view to header pane', ->
+          atom.commands.dispatch(workspaceElement, 'tool-bar:position-top')
+          atom.config.set('tool-bar.fullWidth', true)
+          expect(headerPanelElement.querySelectorAll('.tool-bar').length).toBe(1)
+          expect(topPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(rightPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(footerPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(leftPanelElement.querySelector('.tool-bar')).toBeNull()
+
+    describe 'by triggering tool-bar:position-top with full width disabled', ->
+      it 'adds the tool bar view to top pane', ->
         atom.commands.dispatch(workspaceElement, 'tool-bar:position-top')
+        atom.config.set('tool-bar.fullWidth', false)
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(topPanelElement.querySelectorAll('.tool-bar').length).toBe(1)
         expect(rightPanelElement.querySelector('.tool-bar')).toBeNull()
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(leftPanelElement.querySelector('.tool-bar')).toBeNull()
 
     describe 'by triggering tool-bar:position-right', ->
-      it 'the tool bar view is added to right pane', ->
+      it 'adds the tool bar view to right pane', ->
         atom.commands.dispatch(workspaceElement, 'tool-bar:position-right')
+        atom.config.set('tool-bar.fullWidth', true)
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(topPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(rightPanelElement.querySelectorAll('.tool-bar').length).toBe(1)
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(leftPanelElement.querySelector('.tool-bar')).toBeNull()
 
-    describe 'by triggering tool-bar:position-bottom', ->
-      it 'the tool bar view is added to bottom pane', ->
+    if supportFullWidth
+      describe 'by triggering tool-bar:position-bottom', ->
+        it 'adds the tool bar view to footer pane', ->
+          atom.commands.dispatch(workspaceElement, 'tool-bar:position-bottom')
+          atom.config.set('tool-bar.fullWidth', true)
+          expect(headerPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(topPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(rightPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(footerPanelElement.querySelectorAll('.tool-bar').length).toBe(1)
+          expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull()
+          expect(leftPanelElement.querySelector('.tool-bar')).toBeNull()
+
+    describe 'by triggering tool-bar:position-bottom with full width disabled', ->
+      it 'adds the tool bar view to bottom pane', ->
         atom.commands.dispatch(workspaceElement, 'tool-bar:position-bottom')
+        atom.config.set('tool-bar.fullWidth', false)
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(topPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(rightPanelElement.querySelector('.tool-bar')).toBeNull()
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(bottomPanelElement.querySelectorAll('.tool-bar').length).toBe(1)
         expect(leftPanelElement.querySelector('.tool-bar')).toBeNull()
 
     describe 'by triggering tool-bar:position-left', ->
-      it 'the tool bar view is added to left pane', ->
+      it 'adds the tool bar view to left pane', ->
         atom.commands.dispatch(workspaceElement, 'tool-bar:position-left')
+        atom.config.set('tool-bar.fullWidth', true)
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(topPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(rightPanelElement.querySelector('.tool-bar')).toBeNull()
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull()
         expect(leftPanelElement.querySelectorAll('.tool-bar').length).toBe(1)


### PR DESCRIPTION
Closes #91

This will add a new setting to extend the tool bar full width horizontal, forcing it above or below the tree view. As the tool bar is for the whole workspace (and not just the editor pane), and all programs follow that convention, the default for this setting is `true`.

![screenshot](https://cloud.githubusercontent.com/assets/55841/13202839/9a17fa68-d8a8-11e5-9ae1-a8a23617a0e5.gif)

:rotating_light: **Note:**
This PR requires https://github.com/atom/atom/pull/9274, ~~which has been merged into Atom beta, but not in stable. Let's wait for this to go public first.~~

:green_heart: ~~As expected beta channel is passing, stable is failing.~~ All green.