### PR TITLE
:shirt: CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: "{build}"
+
+platform: x64
+
+skip_tags: true
+
+environment:
+  APM_TEST_PACKAGES:
+
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
+
+install:
+  - ps: Install-Product node 5
+
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+test: off
+deploy: off

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+dependencies:
+  override:
+    - curl -L https://atom.io/download/deb -o atom-amd64.deb
+    - sudo dpkg --install atom-amd64.deb || true
+    - sudo apt-get update
+    - sudo apt-get -f install
+    - apm install
+test:
+  override:
+    - apm test


### PR DESCRIPTION
So we [already](https://github.com/suda/tool-bar/pull/63) have [Travis CI](https://travis-ci.org/suda/tool-bar), this PR will add [Appveyor](http://appveyor.com/) and [CircleCI](https://circleci.com) too.

Previous [PR](https://github.com/suda/tool-bar/pull/120) added Linux to Travis CI, which already ran on OSX. Appveyor tests on Windows and CircleCI also runs on Ubuntu Linux.

All CI follow the instructions provided by [Atom Package CI Scripts](https://github.com/atom/ci).

For this to work on this project (PR's and branches, not forks) we need you, @suda, to register the CI accounts:

* [x] https://circleci.com/add-projects
* [x] https://ci.appveyor.com/projects/new