### PR TITLE
Plugin manager

### DIFF
--- a/lib/tool-bar-manager.coffee
+++ b/lib/tool-bar-manager.coffee
@@ -3,11 +3,13 @@ ToolBarButtonView = require './tool-bar-button-view'
 
 module.exports = class ToolBarManager
   constructor: (@group, @toolBar) ->
+    @visible = true
 
   addButton: (options) ->
     button = new ToolBarButtonView options
     button.group = @group
     @toolBar.addItem button
+    @toolBar.hideItem(button) unless @visible
     button
 
   addSpacer: (options) ->
@@ -17,6 +19,7 @@ module.exports = class ToolBarManager
     spacer.group = @group
     spacer.destroy = -> spacer.remove()
     @toolBar.addItem spacer
+    @toolBar.hideItem(spacer) unless @visible
     spacer
 
   removeItems: ->
@@ -26,12 +29,14 @@ module.exports = class ToolBarManager
       @toolBar.removeItem item
 
   hideItems: ->
+    @visible = false
     @toolBar.items?.filter (item) =>
       item.group is @group
     .forEach (item) =>
       @toolBar.hideItem item
 
   restoreItems: ->
+    @visible = true
     @toolBar.items?.filter (item) =>
       item.group is @group
     .forEach (item) =>

--- a/lib/tool-bar-manager.coffee
+++ b/lib/tool-bar-manager.coffee
@@ -25,5 +25,17 @@ module.exports = class ToolBarManager
     .forEach (item) =>
       @toolBar.removeItem item
 
+  hideItems: ->
+    @toolBar.items?.filter (item) =>
+      item.group is @group
+    .forEach (item) =>
+      @toolBar.hideItem item
+
+  restoreItems: ->
+    @toolBar.items?.filter (item) =>
+      item.group is @group
+    .forEach (item) =>
+      @toolBar.restoreItem item
+
   onDidDestroy: (callback) ->
     @toolBar.emitter.on 'did-destroy', callback

--- a/lib/tool-bar-plugin-manager.coffee
+++ b/lib/tool-bar-plugin-manager.coffee
@@ -23,9 +23,9 @@ module.exports = class ToolBarPluginManager
 
     atom.config.set(settingsKey, true) unless atom.config.get(settingsKey)?
 
-    @subscriptions[name].add atom.config.onDidChange settingsKey, ({newValue, oldValue}) =>
-      console.debug "ToolBarPluginManager:#{settingsKey}:onDidChange", arguments
-      if newValue
+    @subscriptions[name].add atom.config.observe settingsKey, (value) =>
+      console.debug "ToolBarPluginManager:#{settingsKey}:observe", arguments
+      if value
         @plugins[name]?.restoreItems()
       else
         @plugins[name]?.hideItems()

--- a/lib/tool-bar-plugin-manager.coffee
+++ b/lib/tool-bar-plugin-manager.coffee
@@ -18,7 +18,7 @@ module.exports = class ToolBarPluginManager
     @config.plugins.properties[name] =
       type: 'boolean'
       title: name
-      description: "Whether the #{name} plugin is activated and displayed on the Tool Bar."
+      description: "Whether the #{name} plugin is allowed to add items to the Tool Bar."
       default: true
 
     atom.config.set(settingsKey, true) unless atom.config.get(settingsKey)?

--- a/lib/tool-bar-plugin-manager.coffee
+++ b/lib/tool-bar-plugin-manager.coffee
@@ -5,31 +5,39 @@ module.exports = class ToolBarPluginManager
   plugins: {}
   subscriptions: {}
 
+  constructor: (@config) ->
+    console.log 'ToolBarPluginManager::constructor', @config
+
   register: (name, toolBar) ->
     console.debug 'ToolBarPluginManager::register', arguments
     settingsKey = "tool-bar.plugins.#{name}"
 
-    toolBarManager = new ToolBarManager name, toolBar
-
-    @plugins[name] = toolBarManager
+    @plugins[name] = new ToolBarManager name, toolBar
     @subscriptions[name] = new CompositeDisposable
+
+    @config.plugins.properties[name] =
+      type: 'boolean'
+      title: name
+      description: "Whether the #{name} plugin is activated and displayed on the Tool Bar."
+      default: true
 
     atom.config.set(settingsKey, true) unless atom.config.get(settingsKey)?
 
-    @subscriptions[name].add atom.config.onDidChange settingsKey, ({newValue, oldValue}) ->
+    @subscriptions[name].add atom.config.onDidChange settingsKey, ({newValue, oldValue}) =>
       console.debug "ToolBarPluginManager:#{settingsKey}:onDidChange", arguments
       if newValue
-        toolBarManager.restoreItems()
+        @plugins[name]?.restoreItems()
       else
-        toolBarManager.hideItems()
+        @plugins[name]?.hideItems()
 
-    return toolBarManager
+    return @plugins[name]
 
   unregister: (name) ->
     console.debug 'ToolBarPluginManager::unregister', name
     delete @plugins[name]
     @subscriptions[name].destroy()
     delete @subscriptions[name]
+    delete @config.plugins.properties[name]
 
   destroy: ->
     console.debug 'ToolBarPluginManager::destroy'

--- a/lib/tool-bar-plugin-manager.coffee
+++ b/lib/tool-bar-plugin-manager.coffee
@@ -1,0 +1,38 @@
+ToolBarManager = require './tool-bar-manager'
+{CompositeDisposable} = require 'atom'
+
+module.exports = class ToolBarPluginManager
+  plugins: {}
+  subscriptions: {}
+
+  register: (name, toolBar) ->
+    console.debug 'ToolBarPluginManager::register', arguments
+    settingsKey = "tool-bar.plugins.#{name}"
+
+    toolBarManager = new ToolBarManager name, toolBar
+
+    @plugins[name] = toolBarManager
+    @subscriptions[name] = new CompositeDisposable
+
+    atom.config.set(settingsKey, true) unless atom.config.get(settingsKey)?
+
+    @subscriptions[name].add atom.config.onDidChange settingsKey, ({newValue, oldValue}) ->
+      console.debug "ToolBarPluginManager:#{settingsKey}:onDidChange", arguments
+      if newValue
+        toolBarManager.restoreItems()
+      else
+        toolBarManager.hideItems()
+
+    return toolBarManager
+
+  unregister: (name) ->
+    console.debug 'ToolBarPluginManager::unregister', name
+    delete @plugins[name]
+    @subscriptions[name].destroy()
+    delete @subscriptions[name]
+
+  destroy: ->
+    console.debug 'ToolBarPluginManager::destroy'
+    @unregister(plugin) for plugin of @plugins
+    @plugins = null
+    @subscriptions = null

--- a/lib/tool-bar-view.coffee
+++ b/lib/tool-bar-view.coffee
@@ -30,6 +30,12 @@ module.exports = class ToolBarView extends View
     @items.splice (@items.indexOf item), 1
     @drawGutter()
 
+  hideItem: (item) ->
+    item.hide()
+
+  restoreItem: (item) ->
+    item.show()
+
   initialize: ->
     @items = []
     @emitter = new Emitter

--- a/lib/tool-bar.coffee
+++ b/lib/tool-bar.coffee
@@ -5,16 +5,16 @@ module.exports =
   plugins: null
 
   activate: ->
-    ToolBarView = require './tool-bar-view'
+    ToolBarView ?= require './tool-bar-view'
     @toolBar = new ToolBarView()
     #ToolBarManager = require './tool-bar-manager'
-    PluginManager = require './tool-bar-plugin-manager'
-    @plugins = new PluginManager()
+    PluginManager ?= require './tool-bar-plugin-manager'
+    @plugins = new PluginManager(@config)
 
   deactivate: ->
     @plugins.destroy()
     @plugins = null
-    
+
     @toolBar.destroy()
     @toolBar = null
 
@@ -37,6 +37,10 @@ module.exports =
           default: 'Top'
           enum: ['Top', 'Right', 'Bottom', 'Left']
           order: 3
+        plugins:
+          type: 'object'
+          properties: {}
+          order: 5
 
       if typeof atom.workspace.addHeaderPanel is 'function'
         config.fullWidth =

--- a/lib/tool-bar.coffee
+++ b/lib/tool-bar.coffee
@@ -2,13 +2,19 @@ ToolBarManager = null
 
 module.exports =
   toolBar: null
+  plugins: null
 
   activate: ->
     ToolBarView = require './tool-bar-view'
     @toolBar = new ToolBarView()
-    ToolBarManager = require './tool-bar-manager'
+    #ToolBarManager = require './tool-bar-manager'
+    PluginManager = require './tool-bar-plugin-manager'
+    @plugins = new PluginManager()
 
   deactivate: ->
+    @plugins.destroy()
+    @plugins = null
+    
     @toolBar.destroy()
     @toolBar = null
 
@@ -42,4 +48,4 @@ module.exports =
     )()
 
   provideToolBar: ->
-    (group) => new ToolBarManager group, @toolBar
+    (group) => @plugins.register group, @toolBar

--- a/lib/tool-bar.coffee
+++ b/lib/tool-bar.coffee
@@ -1,4 +1,5 @@
-ToolBarManager = null
+ToolBarView = null
+PluginManager = null
 
 module.exports =
   toolBar: null
@@ -7,7 +8,7 @@ module.exports =
   activate: ->
     ToolBarView ?= require './tool-bar-view'
     @toolBar = new ToolBarView()
-    #ToolBarManager = require './tool-bar-manager'
+
     PluginManager ?= require './tool-bar-plugin-manager'
     @plugins = new PluginManager(@config)
 


### PR DESCRIPTION
Closes #49 

![tool-bar-plugin-manager](https://cloud.githubusercontent.com/assets/55841/14060103/1a95a13e-f359-11e5-8108-b9a0a439aabe.gif)

I've been running this for a few days now and it seems to work great.

Some comments:
* Config settings are set programmatically.
* New config settings (by installing package) require an Atom restart (Settings Views cache needs to be cleared for the setting to appear).
* By default all plugins are enabled (backwards compatible).
* Disabling & enabling works instantly (see screenie).
* All plugins settings in the Settings View are grouped in a section named "Plugins".
* Groups can't have description, but I think the plugin descriptions are sufficient.
* I don't think we can remove the config setting when plugin is uninstalled ?!
* Ideas "copied" from [Minimap](https://github.com/atom-minimap/minimap/blob/master/lib/mixins/plugin-management.js) package.
* This opens support for [custom button types](https://github.com/suda/tool-bar/issues/43).

TODO:
* [X] Implement plugin manager.
* [x] Disable on start.
* [x] Hide newly added buttons.
* [ ] Make hiding & restoring of buttons private.
* [ ] Specs.
* [ ] A line mentioning this in the readme.
* [ ] Remove consoles.
* [ ] Test, test, test.
* [ ] Squash commits.