### PR TITLE
Plugin manager 

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -50,6 +50,12 @@ export default class ToolBarButtonView {
     }
   }
 
+  detach () {
+    if (this.element.parentNode) {
+      this.element.parentNode.removeChild(this.element);
+    }
+  }
+
   destroy () {
     this.subscriptions.dispose();
     this.subscriptions = null;

--- a/lib/tool-bar-manager.js
+++ b/lib/tool-bar-manager.js
@@ -8,7 +8,7 @@ export default class ToolBarManager {
     this.group = group;
     this.toolBar = toolBar;
     this._legacy = legacy;
-    this._active = true;
+    this.active = true;
   }
 
   addButton (options) {
@@ -38,26 +38,30 @@ export default class ToolBarManager {
   }
 
   isActive () {
-    return this._active;
+    return this.active;
   }
 
   activate () {
     console.log('ToolBarManager::activate', this.toolBar.items);
-    this._active = true;
-    if (this.toolBar.items) {
-      this.toolBar.items
-        .filter(item => item.group === this.group)
-        .forEach(item => this.toolBar.restoreItem(item));
+    if(!this.active) {
+      this.active = true;
+      if (this.toolBar.items) {
+        this.toolBar.items
+          .filter(item => item.group === this.group)
+          .forEach(item => this.toolBar.restoreItem(item));
+      }
     }
   }
 
   deactivate () {
     console.log('ToolBarManager::deactivate', this.toolBar.items);
-    this._active = false;
-    if (this.toolBar.items) {
-      this.toolBar.items
-        .filter(item => item.group === this.group)
-        .forEach(item => this.toolBar.hideItem(item));
+    if(this.active){
+      this.active = false;
+      if (this.toolBar.items) {
+        this.toolBar.items
+          .filter(item => item.group === this.group)
+          .forEach(item => this.toolBar.hideItem(item));
+      }
     }
   }
 

--- a/lib/tool-bar-manager.js
+++ b/lib/tool-bar-manager.js
@@ -8,12 +8,16 @@ export default class ToolBarManager {
     this.group = group;
     this.toolBar = toolBar;
     this._legacy = legacy;
+    this._active = true;
   }
 
   addButton (options) {
     const button = new ToolBarButtonView(options);
     button.group = this.group;
     this.toolBar.addItem(button);
+    if (!this.isActive()) {
+      this.toolBar.hideItem(button);
+    }
     if (this._legacy) {
       return legacyWrap(button);
     }
@@ -24,10 +28,37 @@ export default class ToolBarManager {
     const spacer = new ToolBarSpacerView(options);
     spacer.group = this.group;
     this.toolBar.addItem(spacer);
+    if (!this.isActive()) {
+      this.toolBar.hideItem(spacer);
+    }
     if (this._legacy) {
       return legacyWrap(spacer);
     }
     return spacer;
+  }
+
+  isActive () {
+    return this._active;
+  }
+
+  activate () {
+    console.log('ToolBarManager::activate', this.toolBar.items);
+    this._active = true;
+    if (this.toolBar.items) {
+      this.toolBar.items
+        .filter(item => item.group === this.group)
+        .forEach(item => this.toolBar.restoreItem(item));
+    }
+  }
+
+  deactivate () {
+    console.log('ToolBarManager::deactivate', this.toolBar.items);
+    this._active = false;
+    if (this.toolBar.items) {
+      this.toolBar.items
+        .filter(item => item.group === this.group)
+        .forEach(item => this.toolBar.hideItem(item));
+    }
   }
 
   removeItems () {

--- a/lib/tool-bar-plugin-manager.js
+++ b/lib/tool-bar-plugin-manager.js
@@ -1,0 +1,61 @@
+'use babel';
+
+import ToolBarManager from './tool-bar-manager';
+import { CompositeDisposable } from 'atom';
+
+export default class ToolBarPluginManager {
+  plugins = {};
+  subscriptions = {};
+
+  constructor(config) {
+    this.config = config;
+    console.log('ToolBarPluginManager::constructor', this.config);
+  }
+
+  register(name, toolBar, legacy) {
+    console.debug('ToolBarPluginManager::register', arguments);
+    let settingsKey = `tool-bar.plugins.${name}`;
+
+    this.plugins[name] = new ToolBarManager(name, toolBar, legacy);
+    this.subscriptions[name] = new CompositeDisposable();
+
+    this.config.plugins[name] = {
+      type: 'boolean',
+      title: name,
+      description: `Whether the ${name} plugin is allowed to add items to the Tool Bar.`,
+      default: true
+    };
+
+    if (atom.config.get(settingsKey) == null) {
+      atom.config.set(settingsKey, true);
+    }
+
+    this.subscriptions[name].add(atom.config.observe(settingsKey, (value) => {
+      console.debug(`ToolBarPluginManager:${settingsKey}:observe`, arguments);
+      if (value) {
+        this.plugins[name].activate();
+      } else {
+        this.plugins[name].deactivate();
+      }
+    }));
+
+    return this.plugins[name];
+  }
+
+  unregister(name) {
+    console.debug('ToolBarPluginManager::unregister', name);
+    delete this.plugins[name];
+    this.subscriptions[name].destroy();
+    delete this.subscriptions[name];
+    delete this.config.plugins[name];
+  }
+
+  destroy() {
+    console.debug('ToolBarPluginManager::destroy');
+    for (let plugin in this.plugins) {
+      this.unregister(plugin);
+    }
+    this.plugins = null;
+    this.subscriptions = null;
+  }
+};

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -72,40 +72,49 @@ export default class ToolBarView {
 
   addItem (newItem) {
     newItem.priority = this.calculatePriority(newItem);
+    const index = this.calculateIndex(newItem);
+    const nextItem = this.items[index];
+    this.items.splice(index, 0, newItem);
+    this.attachItem(newItem, nextItem);
+    this.drawGutter();
+    return nextItem;
+  }
 
+  attachItem (newItem, nextItem) {
     if (atom.devMode) {
       newItem.element.dataset.group = newItem.group;
       newItem.element.dataset.priority = newItem.priority;
     }
+    this.element.insertBefore(
+      newItem.element,
+      nextItem && nextItem.element.parentNode ? nextItem.element : null
+    );
+  }
 
+  calculateIndex (newItem) {
     let index = this.items.findIndex(existingItem =>
-      (existingItem.priority > newItem.priority));
+      existingItem.element.parentNode &&
+      existingItem.priority > newItem.priority);
     if (index === -1) {
       index = this.items.length;
     }
-    const nextItem = this.items[index];
-
-    this.items.splice(index, 0, newItem);
-
-    this.element.insertBefore(
-      newItem.element,
-      nextItem ? nextItem.element : null
-    );
-
-    this.drawGutter();
-
-    return nextItem;
+    return index;
   }
 
   hideItem(item) {
-    console.log('ToolBarView::hideItem', item);
-    item.element.style.display = "none";
+    console.log('ToolBarView::hideItem', item, item.element.parentNode);
+    //item.element.style.display = "none";
+    this.element.removeChild(item.element);
     this.drawGutter();
   }
 
   restoreItem(item) {
     console.log('ToolBarView::restoreItem', item);
-    item.element.style.display = "block";
+    //item.element.style.display = "block";
+    item.priority = this.calculatePriority(item);
+    const index = this.calculateIndex(item);
+    const nextItem = this.items[index];
+    this.attachItem(item, nextItem);
     this.drawGutter();
   }
 
@@ -137,7 +146,7 @@ export default class ToolBarView {
     if (!isNaN(item.priority)) {
       return item.priority;
     }
-    const lastItem = this.items.filter(i => i.group !== item.group).pop();
+    const lastItem = this.items.filter(i => i.group !== item.group && i.element.parentNode).pop();
     return lastItem && !isNaN(lastItem.priority)
       ? lastItem.priority + 1
       : 50;

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -97,6 +97,18 @@ export default class ToolBarView {
     return nextItem;
   }
 
+  hideItem(item) {
+    console.log('ToolBarView::hideItem', item);
+    item.element.style.display = "none";
+    this.drawGutter();
+  }
+
+  restoreItem(item) {
+    console.log('ToolBarView::restoreItem', item);
+    item.element.style.display = "block";
+    this.drawGutter();
+  }
+
   removeItem (item) {
     item.destroy();
     this.items.splice(this.items.indexOf(item), 1);

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -1,32 +1,36 @@
 'use babel';
 
-import ToolBarManager from './tool-bar-manager';
 import ToolBarView from './tool-bar-view';
+import PluginManager from './tool-bar-plugin-manager';
 
 let toolBar = null;
+let plugins = null;
 
 export function activate () {
   toolBar = new ToolBarView();
+  plugins = new PluginManager(config);
 }
 
 export function deactivate () {
   toolBar.destroy();
   toolBar = null;
+  plugins.destroy();
+  plugins = null;
 }
 
 export function provideToolBar () {
-  return (group) => new ToolBarManager(group, toolBar);
+  return (group) => plugins.register(group, toolBar);
 }
 
 export function provideToolBarLegacy () {
   return (group) => {
     const Grim = require('grim');
     Grim.deprecate('Please update to the latest tool-bar provider service.');
-    return new ToolBarManager(group, toolBar, true);
+    return plugins.register(group, toolBar, true);
   };
 }
 
-export const config = {
+export let config = {
   visible: {
     type: 'boolean',
     default: true,
@@ -48,6 +52,11 @@ export const config = {
     type: 'boolean',
     default: true,
     order: 4
+  },
+  plugins: {
+    type: 'object',
+    default: {},
+    order: 5
   }
 };
 


### PR DESCRIPTION
Closes #49 

![tool-bar-plugin-manager](https://cloud.githubusercontent.com/assets/55841/14060103/1a95a13e-f359-11e5-8108-b9a0a439aabe.gif)

I've been running this for a few days now and it seems to work great.

Some comments:
* Config settings are set programmatically.
* New config settings (by installing package) require an Atom restart (Settings Views cache needs to be cleared for the setting to appear).
* By default all plugins are enabled (backwards compatible).
* Disabling & enabling works instantly (see screenie).
* All plugins settings in the Settings View are grouped in a section named "Plugins".
* Groups can't have description, but I think the plugin descriptions are sufficient.
* I don't think we can remove the config setting when plugin is uninstalled ?!
* Ideas "copied" from [Minimap](https://github.com/atom-minimap/minimap/blob/master/lib/mixins/plugin-management.js) package.
* This opens support for [custom button types](https://github.com/suda/tool-bar/issues/43).

TODO:
* [x] Convert to ES6.
* [X] Implement plugin manager.
* [x] Disable on start.
* [x] Hide newly added buttons.
* [x] Make hiding & restoring of buttons private.
* [ ] Specs.
* [ ] A line mentioning this in the readme.
* [ ] Remove consoles.
* [ ] Test, test, test.
* [ ] Squash commits.