### PR TITLE
[RFC] Remove space-pen

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -1,69 +1,75 @@
 'use babel';
 
 import {CompositeDisposable} from 'atom';
-import {View} from 'space-pen';
 
 let prevFocusedElm = null;
 
-export default class ToolBarButtonView extends View {
-  static content () {
-    return this.button({class: 'btn btn-default tool-bar-btn'});
-  }
+export default class ToolBarButtonView {
 
   constructor (options) {
-    super(options);
-
+    this.element = document.createElement('button');
     this.subscriptions = new CompositeDisposable();
+
     this.priority = options.priority;
     this.options = options;
 
-    if (this.priority < 0) {
-      this.addClass('tool-bar-item-align-end');
-    }
-
     if (options.tooltip) {
-      this.prop('title', options.tooltip);
+      this.element.title = options.tooltip;
       this.subscriptions.add(
-        atom.tooltips.add(this, {
+        atom.tooltips.add(this.element, {
           title: options.tooltip,
           placement: getTooltipPlacement
         })
       );
     }
 
-    if (options.iconset) {
-      this.addClass(`${options.iconset} ${options.iconset}-${options.icon}`);
-    } else {
-      this.addClass(`icon-${options.icon}`);
+    const classNames = ['btn', 'btn-default', 'tool-bar-btn'];
+    if (this.priority < 0) {
+      classNames.push('tool-bar-item-align-end');
     }
+    if (options.iconset) {
+      classNames.push(options.iconset, `${options.iconset}-${options.icon}`);
+    } else {
+      classNames.push(`icon-${options.icon}`);
+    }
+
+    this.element.classList.add(...classNames);
 
     this._onClick = this._onClick.bind(this);
     this._onMouseOver = this._onMouseOver.bind(this);
 
-    this.on('click', this._onClick);
-    this.on('mouseover', this._onMouseOver);
+    this.element.addEventListener('click', this._onClick);
+    this.element.addEventListener('mouseover', this._onMouseOver);
   }
 
   setEnabled (enabled) {
     if (enabled) {
-      this.removeClass('disabled');
+      this.element.classList.remove('disabled');
     } else {
-      this.addClass('disabled');
+      this.element.classList.add('disabled');
     }
   }
 
   destroy () {
     this.subscriptions.dispose();
     this.subscriptions = null;
-    this.remove();
+
+    if (this.element.parentNode) {
+      this.element.parentNode.removeChild(this.element);
+    }
+
+    this.element.removeEventListener('click', this._onClick);
+    this.element.removeEventListener('mouseover', this._onMouseOver);
+    this.element = null;
   }
 
   _onClick (e) {
     getPrevFocusedElm().focus();
-    if (!this.hasClass('disabled')) {
+    if (!this.element.classList.contains('disabled')) {
       executeCallback(this.options, e);
     }
-    return false;
+    e.preventDefault();
+    e.stopPropagation();
   }
 
   _onMouseOver (e) {

--- a/lib/tool-bar-manager.js
+++ b/lib/tool-bar-manager.js
@@ -51,5 +51,6 @@ function legacyWrap (view) {
       wrapped[name] = (...args) => view[name](...args);
     }
   });
+  wrapped.element = view.element;
   return wrapped;
 }

--- a/lib/tool-bar-manager.js
+++ b/lib/tool-bar-manager.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import ToolBarButtonView from './tool-bar-button-view';
-import {$$} from 'space-pen';
+import ToolBarSpacerView from './tool-bar-spacer-view';
 
 export default class ToolBarManager {
   constructor (group, toolBar) {
@@ -17,15 +17,8 @@ export default class ToolBarManager {
   }
 
   addSpacer (options) {
-    const spacer = $$(function () {
-      return this.hr({class: 'tool-bar-spacer'});
-    });
-    spacer.priority = options != null ? options.priority : void 0;
-    if (spacer.priority < 0) {
-      spacer.addClass('tool-bar-item-align-end');
-    }
+    const spacer = new ToolBarSpacerView(options);
     spacer.group = this.group;
-    spacer.destroy = () => { spacer.remove(); };
     this.toolBar.addItem(spacer);
     return spacer;
   }

--- a/lib/tool-bar-manager.js
+++ b/lib/tool-bar-manager.js
@@ -4,15 +4,19 @@ import ToolBarButtonView from './tool-bar-button-view';
 import ToolBarSpacerView from './tool-bar-spacer-view';
 
 export default class ToolBarManager {
-  constructor (group, toolBar) {
+  constructor (group, toolBar, legacy) {
     this.group = group;
     this.toolBar = toolBar;
+    this._legacy = legacy;
   }
 
   addButton (options) {
     const button = new ToolBarButtonView(options);
     button.group = this.group;
     this.toolBar.addItem(button);
+    if (this._legacy) {
+      return legacyWrap(button);
+    }
     return button;
   }
 
@@ -20,6 +24,9 @@ export default class ToolBarManager {
     const spacer = new ToolBarSpacerView(options);
     spacer.group = this.group;
     this.toolBar.addItem(spacer);
+    if (this._legacy) {
+      return legacyWrap(spacer);
+    }
     return spacer;
   }
 
@@ -34,4 +41,15 @@ export default class ToolBarManager {
   onDidDestroy (callback) {
     this.toolBar.emitter.on('did-destroy', callback);
   }
+}
+
+function legacyWrap (view) {
+  const $ = require('jquery');
+  const wrapped = $(view.element);
+  ['setEnabled', 'destroy'].forEach(name => {
+    if (typeof view[name] === 'function') {
+      wrapped[name] = (...args) => view[name](...args);
+    }
+  });
+  return wrapped;
 }

--- a/lib/tool-bar-spacer-view.js
+++ b/lib/tool-bar-spacer-view.js
@@ -4,10 +4,11 @@ export default class ToolBarSpacerView {
   constructor (options) {
     this.element = document.createElement('hr');
     this.priority = options && options.priority;
-    this.element.classList.add('tool-bar-spacer');
+    const classNames = 'tool-bar-spacer';
     if (this.priority < 0) {
-      this.element.classList.add('tool-bar-item-align-end');
+      classNames.push('tool-bar-item-align-end');
     }
+    this.element.classList.add(...classNames);
   }
 
   destroy () {

--- a/lib/tool-bar-spacer-view.js
+++ b/lib/tool-bar-spacer-view.js
@@ -4,7 +4,7 @@ export default class ToolBarSpacerView {
   constructor (options) {
     this.element = document.createElement('hr');
     this.priority = options && options.priority;
-    const classNames = 'tool-bar-spacer';
+    const classNames = ['tool-bar-spacer'];
     if (this.priority < 0) {
       classNames.push('tool-bar-item-align-end');
     }

--- a/lib/tool-bar-spacer-view.js
+++ b/lib/tool-bar-spacer-view.js
@@ -1,0 +1,19 @@
+'use babel';
+
+export default class ToolBarSpacerView {
+  constructor (options) {
+    this.element = document.createElement('hr');
+    this.priority = options && options.priority;
+    this.element.classList.add('tool-bar-spacer');
+    if (this.priority < 0) {
+      this.element.classList.add('tool-bar-item-align-end');
+    }
+  }
+
+  destroy () {
+    if (this.element.parentNode) {
+      this.element.parentNode.removeChild(this.element);
+    }
+    this.element = null;
+  }
+}

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -1,19 +1,14 @@
 'use babel';
 
 import {CompositeDisposable, Emitter} from 'atom';
-import {View} from 'space-pen';
 
 const supportFullWidth = typeof atom.workspace.addHeaderPanel === 'function';
 
-export default class ToolBarView extends View {
-
-  static content () {
-    return this.div({class: 'tool-bar'});
-  }
+export default class ToolBarView {
 
   constructor () {
-    super();
-
+    this.element = document.createElement('div');
+    this.element.classList.add('tool-bar');
     this.items = [];
     this.emitter = new Emitter();
     this.subscriptions = new CompositeDisposable();
@@ -71,7 +66,7 @@ export default class ToolBarView extends View {
 
     this.drawGutter = this.drawGutter.bind(this);
 
-    this.on('scroll', this.drawGutter);
+    this.element.addEventListener('scroll', this.drawGutter);
     window.addEventListener('resize', this.drawGutter);
   }
 
@@ -79,8 +74,8 @@ export default class ToolBarView extends View {
     newItem.priority = this.calculatePriority(newItem);
 
     if (atom.devMode) {
-      newItem.get(0).dataset.group = newItem.group;
-      newItem.get(0).dataset.priority = newItem.priority;
+      newItem.element.dataset.group = newItem.group;
+      newItem.element.dataset.priority = newItem.priority;
     }
 
     let index = this.items.findIndex(existingItem =>
@@ -92,9 +87,10 @@ export default class ToolBarView extends View {
 
     this.items.splice(index, 0, newItem);
 
-    const newElement = atom.views.getView(newItem);
-    const nextElement = atom.views.getView(nextItem);
-    this.element.insertBefore(newElement, nextElement);
+    this.element.insertBefore(
+      newItem.element,
+      nextItem ? nextItem.element : null
+    );
 
     this.drawGutter();
 
@@ -115,8 +111,9 @@ export default class ToolBarView extends View {
     this.subscriptions = null;
 
     this.hide();
-    this.remove();
+    this.element.removeEventListener('scroll', this.drawGutter);
     window.removeEventListener('resize', this.drawGutter);
+    this.element = null;
 
     this.emitter.emit('did-destroy');
     this.emitter.dispose();
@@ -134,14 +131,23 @@ export default class ToolBarView extends View {
   }
 
   updateSize (size) {
-    this.removeClass('tool-bar-12px tool-bar-16px tool-bar-24px tool-bar-32px');
-    this.addClass(`tool-bar-${size}`);
+    this.element.classList.remove(
+      'tool-bar-12px',
+      'tool-bar-16px',
+      'tool-bar-24px',
+      'tool-bar-32px'
+    );
+    this.element.classList.add(`tool-bar-${size}`);
   }
 
   updatePosition (position) {
-    this.removeClass(
-      'tool-bar-top tool-bar-right tool-bar-bottom tool-bar-left ' +
-      'tool-bar-horizontal tool-bar-vertical'
+    this.element.classList.remove(
+      'tool-bar-top',
+      'tool-bar-right',
+      'tool-bar-bottom',
+      'tool-bar-left',
+      'tool-bar-horizontal',
+      'tool-bar-vertical'
     );
 
     const fullWidth = supportFullWidth && atom.config.get('tool-bar.fullWidth');
@@ -149,28 +155,28 @@ export default class ToolBarView extends View {
     switch (position) {
       case 'Top':
         this.panel = fullWidth
-          ? atom.workspace.addHeaderPanel({item: this})
-          : atom.workspace.addTopPanel({item: this});
+          ? atom.workspace.addHeaderPanel({item: this.element})
+          : atom.workspace.addTopPanel({item: this.element});
         break;
       case 'Right':
-        this.panel = atom.workspace.addRightPanel({item: this});
+        this.panel = atom.workspace.addRightPanel({item: this.element});
         break;
       case 'Bottom':
         this.panel = fullWidth
-          ? atom.workspace.addFooterPanel({item: this})
-          : atom.workspace.addBottomPanel({item: this});
+          ? atom.workspace.addFooterPanel({item: this.element})
+          : atom.workspace.addBottomPanel({item: this.element});
         break;
       case 'Left':
-        this.panel = atom.workspace.addLeftPanel({item: this, priority: 50});
+        this.panel = atom.workspace.addLeftPanel({item: this.element, priority: 50});
         break;
     }
 
-    this.addClass(`tool-bar-${position.toLowerCase()}`);
+    this.element.classList.add(`tool-bar-${position.toLowerCase()}`);
 
     if (position === 'Top' || position === 'Bottom') {
-      this.addClass('tool-bar-horizontal');
+      this.element.classList.add('tool-bar-horizontal');
     } else {
-      this.addClass('tool-bar-vertical');
+      this.element.classList.add('tool-bar-vertical');
     }
 
     this.updateMenu(position);
@@ -196,25 +202,27 @@ export default class ToolBarView extends View {
   }
 
   drawGutter () {
-    this.removeClass('gutter-top gutter-bottom');
+    this.element.classList.remove('gutter-top', 'gutter-bottom');
 
-    const visibleHeight = this.height();
+    const visibleHeight = this.element.getBoundingClientRect().height;
     const scrollHeight = this.element.scrollHeight;
     const hiddenHeight = scrollHeight - visibleHeight;
 
     if (visibleHeight < scrollHeight) {
-      if (this.scrollTop() > 0) {
-        this.addClass('gutter-top');
+      if (this.element.scrollTop > 0) {
+        this.element.classList.add('gutter-top');
       }
-      if (this.scrollTop() < hiddenHeight) {
-        this.addClass('gutter-bottom');
+      if (this.element.scrollTop < hiddenHeight) {
+        this.element.classList.add('gutter-bottom');
       }
     }
   }
 
   hide () {
     if (this.panel != null) {
-      this.detach();
+      if (this.element.parentNode) {
+        this.element.parentNode.removeChild(this.element);
+      }
       this.panel.destroy();
       this.panel = null;
     }
@@ -227,7 +235,7 @@ export default class ToolBarView extends View {
   }
 
   toggle () {
-    if (this.hasParent()) {
+    if (this.element.parentNode) {
       this.hide();
       atom.config.set('tool-bar.visible', false);
     } else {

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -112,8 +112,9 @@ export default class ToolBarView {
 
     this.hide();
     this.element.removeEventListener('scroll', this.drawGutter);
-    window.removeEventListener('resize', this.drawGutter);
     this.element = null;
+
+    window.removeEventListener('resize', this.drawGutter);
 
     this.emitter.emit('did-destroy');
     this.emitter.dispose();
@@ -171,13 +172,13 @@ export default class ToolBarView {
         break;
     }
 
-    this.element.classList.add(`tool-bar-${position.toLowerCase()}`);
-
+    const classNames = [`tool-bar-${position.toLowerCase()}`];
     if (position === 'Top' || position === 'Bottom') {
-      this.element.classList.add('tool-bar-horizontal');
+      classNames.push('tool-bar-horizontal');
     } else {
-      this.element.classList.add('tool-bar-vertical');
+      classNames.push('tool-bar-vertical');
     }
+    this.element.classList.add(...classNames);
 
     this.updateMenu(position);
     this.drawGutter();

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -18,6 +18,10 @@ export function provideToolBar () {
   return (group) => new ToolBarManager(group, toolBar);
 }
 
+export function provideToolBarLegacy () {
+  return (group) => new ToolBarManager(group, toolBar, true);
+}
+
 export const config = {
   visible: {
     type: 'boolean',

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -19,7 +19,11 @@ export function provideToolBar () {
 }
 
 export function provideToolBarLegacy () {
-  return (group) => new ToolBarManager(group, toolBar, true);
+  return (group) => {
+    const Grim = require('grim');
+    Grim.deprecate('Please update to the latest tool-bar provider service.');
+    return new ToolBarManager(group, toolBar, true);
+  };
 }
 
 export const config = {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"lint": "eslint --format tap . && remark ."
 	},
 	"dependencies": {
+		"grim": "^2.0.0",
 		"jquery": "2.1.4"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
 	"scripts": {
 		"lint": "eslint --format tap . && remark ."
 	},
-	"dependencies": {
-		"space-pen": "^5.1.2"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"babel-eslint": "^6.0.4",
 		"eslint": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
 	"scripts": {
 		"lint": "eslint --format tap . && remark ."
 	},
-	"dependencies": {},
+	"dependencies": {
+		"jquery": "2.1.4"
+	},
 	"devDependencies": {
 		"babel-eslint": "^6.0.4",
 		"eslint": "^2.9.0",
@@ -32,7 +34,8 @@
 		"tool-bar": {
 			"description": "A container for buttons at workspace edge",
 			"versions": {
-				"0.1.0": "provideToolBar"
+				"0.1.0": "provideToolBarLegacy",
+				"1.0.0": "provideToolBar"
 			}
 		}
 	}

--- a/spec/tool-bar-legacy-spec.js
+++ b/spec/tool-bar-legacy-spec.js
@@ -39,6 +39,11 @@ describe('Tool Bar package (legacy)', () => {
     });
   });
 
+  afterEach(() => {
+    const Grim = require('grim');
+    Grim.clearDeprecations();
+  });
+
   describe('@activate', () => {
     it('appends only one tool bar', () => {
       expect(workspaceElement.querySelectorAll('.tool-bar').length).toBe(1);

--- a/spec/tool-bar-legacy-spec.js
+++ b/spec/tool-bar-legacy-spec.js
@@ -333,7 +333,7 @@ describe('Tool Bar package (legacy)', () => {
       describe('by clicking', () => {
         it('stops event bubbling', () => {
           const clickSpy = jasmine.createSpy();
-          toolBar.onclick = clickSpy;
+          toolBar.addEventListener('click', clickSpy);
           const button = toolBarAPI.addButton({});
           button.click();
           expect(clickSpy).not.toHaveBeenCalled();

--- a/spec/tool-bar-legacy-spec.js
+++ b/spec/tool-bar-legacy-spec.js
@@ -1,0 +1,611 @@
+'use babel';
+
+/* eslint-env browser */
+
+const supportFullWidth = typeof atom.workspace.addHeaderPanel === 'function';
+
+function getGlyph (elm) {
+  return window.getComputedStyle(elm, ':before')
+    .getPropertyValue('content')
+    .charCodeAt(1)
+    .toString(16)
+    .toLowerCase();
+}
+
+function buildClickEvent ({altKey, ctrlKey, shiftKey} = {}) {
+  const event = new MouseEvent('click');
+  if (altKey != null) {
+    Object.defineProperty(event, 'altKey', { get: () => altKey });
+  }
+  if (ctrlKey != null) {
+    Object.defineProperty(event, 'ctrlKey', { get: () => ctrlKey });
+  }
+  if (shiftKey != null) {
+    Object.defineProperty(event, 'shiftKey', { get: () => shiftKey });
+  }
+  return event;
+}
+
+describe('Tool Bar package (legacy)', () => {
+  let workspaceElement;
+  let toolBarService;
+  let toolBarAPI;
+
+  beforeEach(() => {
+    workspaceElement = atom.views.getView(atom.workspace);
+    waitsForPromise(async () => {
+      const pack = await atom.packages.activatePackage('tool-bar');
+      toolBarService = pack.mainModule.provideToolBarLegacy();
+    });
+  });
+
+  describe('@activate', () => {
+    it('appends only one tool bar', () => {
+      expect(workspaceElement.querySelectorAll('.tool-bar').length).toBe(1);
+      atom.workspace.getActivePane().splitRight({copyActiveItem: true});
+      expect(workspaceElement.querySelectorAll('.tool-bar').length).toBe(1);
+    });
+  });
+
+  describe('@deactivate', () => {
+    it('removes the tool bar view', () => {
+      atom.packages.deactivatePackage('tool-bar');
+      expect(workspaceElement.querySelector('.tool-bar')).toBeNull();
+    });
+
+    it('notifies on destroy', () => {
+      const spy = jasmine.createSpy();
+      toolBarAPI = toolBarService('specs-tool-bar');
+      toolBarAPI.onDidDestroy(spy);
+      atom.packages.deactivatePackage('tool-bar');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('provides a service API', () => {
+    it('for others to use', () => {
+      expect(toolBarService).toBeDefined();
+      expect(typeof toolBarService).toBe('function');
+    });
+
+    describe('which can add a button', () => {
+      let toolBar;
+
+      beforeEach(() => {
+        toolBarAPI = toolBarService('specs-tool-bar');
+        toolBar = workspaceElement.querySelector('.tool-bar');
+      });
+
+      it('by third-party packages', () => {
+        expect(toolBarAPI).toBeDefined();
+        expect(toolBarAPI.group).toBe('specs-tool-bar');
+      });
+
+      it('with minimum settings', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about'
+        });
+        expect(toolBar.children.length).toBe(1);
+        expect(toolBar.firstChild.classList.contains('icon-octoface')).toBe(true);
+      });
+
+      it('with tooltip', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about',
+          tooltip: 'About Atom'
+        });
+        expect(toolBar.children.length).toBe(1);
+        expect(toolBar.firstChild.dataset.originalTitle).toBe('About Atom');
+      });
+
+      it('using default iconset', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about'
+        });
+        expect(toolBar.firstChild.classList.contains('icon-octoface')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('f008');
+      });
+
+      it('using Ionicons iconset', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'ionic',
+          callback: 'application:about',
+          iconset: 'ion'
+        });
+        expect(toolBar.firstChild.classList.contains('ion')).toBe(true);
+        expect(toolBar.firstChild.classList.contains('ion-ionic')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('f14b');
+      });
+
+      it('using Font Awesome iconset', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'fort-awesome',
+          callback: 'application:about',
+          iconset: 'fa'
+        });
+        expect(toolBar.firstChild.classList.contains('fa')).toBe(true);
+        expect(toolBar.firstChild.classList.contains('fa-fort-awesome')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('f286');
+      });
+
+      it('using Foundation iconset', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'foundation',
+          callback: 'application:about',
+          iconset: 'fi'
+        });
+        expect(toolBar.firstChild.classList.contains('fi')).toBe(true);
+        expect(toolBar.firstChild.classList.contains('fi-foundation')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('f152');
+      });
+
+      it('using Icomoon iconset', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'IcoMoon',
+          callback: 'application:about',
+          iconset: 'icomoon'
+        });
+        expect(toolBar.firstChild.classList.contains('icomoon')).toBe(true);
+        expect(toolBar.firstChild.classList.contains('icomoon-IcoMoon')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('eaea');
+      });
+
+      it('using Devicon iconset', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'atom-original',
+          callback: 'application:about',
+          iconset: 'devicon'
+        });
+        expect(toolBar.firstChild.classList.contains('devicon')).toBe(true);
+        expect(toolBar.firstChild.classList.contains('devicon-atom-original')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('e624');
+      });
+
+      it('using Material Design Icons iconset', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'material-ui',
+          callback: 'application:about',
+          iconset: 'mdi'
+        });
+        expect(toolBar.firstChild.classList.contains('mdi')).toBe(true);
+        expect(toolBar.firstChild.classList.contains('mdi-material-ui')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('f449');
+      });
+
+      it('and disabling it', () => {
+        const button = toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about'
+        });
+        button.setEnabled(false);
+        expect(toolBar.children.length).toBe(1);
+        expect(toolBar.firstChild.classList.contains('disabled')).toBe(true);
+      });
+      it('clicking button with command callback', () => {
+        const spy = jasmine.createSpy();
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about'
+        });
+        jasmine.attachToDOM(toolBar);
+        atom.commands.onWillDispatch(spy);
+        toolBar.firstChild.click();
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mostRecentCall.args[0].type).toEqual('application:about');
+      });
+
+      it('clicking button with function callback', () => {
+        const spy = jasmine.createSpy();
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: spy
+        });
+        jasmine.attachToDOM(toolBar);
+        toolBar.firstChild.click();
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('clicking button with function callback containing data', () => {
+        const spy = jasmine.createSpy();
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: spy,
+          data: 'foo'
+        });
+        toolBar.firstChild.click();
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mostRecentCall.args[0]).toEqual('foo');
+      });
+
+      it('and restores focus after click', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'editor:select-line',
+          tooltip: 'Select line'
+        });
+        const previouslyFocusedElement = document.activeElement;
+        toolBar.firstChild.dispatchEvent(new Event('mouseover'));
+        toolBar.firstChild.focus();
+        toolBar.firstChild.click();
+        expect(document.activeElement).toBe(previouslyFocusedElement);
+      });
+
+      describe('using priority setting', () => {
+        it('works with default values', () => {
+          toolBarAPI.addButton({
+            icon: 'octoface',
+            callback: 'application:about'
+          });
+          toolBarAPI.addButton({
+            icon: 'file',
+            callback: 'application:about'
+          });
+          toolBarAPI.addButton({
+            icon: 'folder',
+            callback: 'application:about'
+          });
+          expect(toolBar.children.length).toBe(3);
+          expect(toolBar.children[0].classList.contains('icon-octoface')).toBe(true);
+          expect(toolBar.children[1].classList.contains('icon-file')).toBe(true);
+          expect(toolBar.children[2].classList.contains('icon-folder')).toBe(true);
+        });
+
+        it('works with custom values', () => {
+          toolBarAPI.addButton({
+            icon: 'octoface',
+            callback: 'application:about'
+          });
+          toolBarAPI.addButton({
+            icon: 'file',
+            callback: 'application:about',
+            priority: 10
+          });
+          toolBarAPI.addButton({
+            icon: 'folder',
+            callback: 'application:about',
+            priority: 20
+          });
+          expect(toolBar.children.length).toBe(3);
+          expect(toolBar.children[0].classList.contains('icon-file')).toBe(true);
+          expect(toolBar.children[1].classList.contains('icon-folder')).toBe(true);
+          expect(toolBar.children[2].classList.contains('icon-octoface')).toBe(true);
+        });
+
+        it('works with unordered values', () => {
+          toolBarAPI.addButton({
+            icon: 'octoface',
+            callback: 'application:about'
+          });
+          toolBarAPI.addButton({
+            icon: 'file',
+            callback: 'application:about',
+            priority: 20
+          });
+          toolBarAPI.addButton({
+            icon: 'folder',
+            callback: 'application:about',
+            priority: 10
+          });
+          expect(toolBar.children.length).toBe(3);
+          expect(toolBar.children[0].classList.contains('icon-folder')).toBe(true);
+          expect(toolBar.children[1].classList.contains('icon-file')).toBe(true);
+          expect(toolBar.children[2].classList.contains('icon-octoface')).toBe(true);
+        });
+
+        it('works with negative values', () => {
+          toolBarAPI.addButton({
+            icon: 'octoface',
+            callback: 'application:about'
+          });
+          toolBarAPI.addButton({
+            icon: 'file',
+            callback: 'application:about',
+            priority: 10
+          });
+          toolBarAPI.addButton({
+            icon: 'folder',
+            callback: 'application:about',
+            priority: -50
+          });
+          toolBarAPI.addButton({
+            icon: 'gear',
+            callback: 'application:about',
+            priority: -60
+          });
+          expect(toolBar.children.length).toBe(4);
+          expect(toolBar.children[0].classList.contains('icon-gear')).toBe(true);
+          expect(toolBar.children[1].classList.contains('icon-folder')).toBe(true);
+          expect(toolBar.children[2].classList.contains('icon-file')).toBe(true);
+          expect(toolBar.children[3].classList.contains('icon-octoface')).toBe(true);
+        });
+      });
+
+      describe('by clicking', () => {
+        it('stops event bubbling', () => {
+          const clickSpy = jasmine.createSpy();
+          toolBar.onclick = clickSpy;
+          const button = toolBarAPI.addButton({});
+          button.click();
+          expect(clickSpy).not.toHaveBeenCalled();
+        });
+
+        describe('with modifiers', () => {
+          describe('and command callback', () => {
+            let spy = null;
+
+            beforeEach(() => {
+              spy = jasmine.createSpy();
+              toolBarAPI.addButton({
+                icon: 'octoface',
+                callback: {
+                  '': 'tool-bar:modifier-default',
+                  'alt': 'tool-bar:modifier-alt',
+                  'ctrl': 'tool-bar:modifier-ctrl',
+                  'shift': 'tool-bar:modifier-shift',
+                  'shift+alt': 'tool-bar:modifier-shift-alt',
+                  'alt+shift': 'tool-bar:modifier-alt-shift',
+                  'ctrl+shift': 'tool-bar:modifier-ctrl-shift',
+                  'alt ctrl-shift': 'tool-bar:modifier-alt-ctrl-shift'
+                }},
+                jasmine.attachToDOM(toolBar),
+                atom.commands.onWillDispatch(spy)
+              );
+            });
+
+            it('works without modifiers', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent());
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-default');
+            });
+
+            it('works with alt key', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt');
+            });
+
+            it('works with ctrl key', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                ctrlKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-ctrl');
+            });
+
+            it('works with shift key', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                shiftKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-shift');
+            });
+
+            it('works with alt & shift key', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true,
+                shiftKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-shift');
+            });
+
+            it('works with ctrl & shift key', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({ctrlKey: true, shiftKey: true}));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-ctrl-shift');
+            });
+
+            it('works with alt & ctrl & shift key', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true,
+                ctrlKey: true,
+                shiftKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-ctrl-shift');
+            });
+
+            it('works when modifier callback isn\'t defined', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true,
+                ctrlKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-default');
+            });
+
+            it('works with last defined modifiers when there are duplicates', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true,
+                shiftKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-shift');
+            });
+
+            it('works with any seperator between modifiers', () => {
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true,
+                ctrlKey: true,
+                shiftKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0].type).toEqual('tool-bar:modifier-alt-ctrl-shift');
+            });
+          });
+
+          describe('and function callback', () => {
+            it('executes', () => {
+              const spy = jasmine.createSpy();
+              toolBarAPI.addButton({
+                icon: 'octoface',
+                callback: {
+                  '': 'tool-bar:modifier-default',
+                  'alt': spy
+                }
+              });
+              jasmine.attachToDOM(toolBar);
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+            });
+
+            it('executes with data', () => {
+              const spy = jasmine.createSpy();
+              toolBarAPI.addButton({
+                icon: 'octoface',
+                callback: {
+                  '': 'tool-bar:modifier-default',
+                  'alt': spy
+                },
+                data: 'foo'
+              });
+              toolBar.firstChild.dispatchEvent(buildClickEvent({
+                altKey: true
+              }));
+              expect(spy).toHaveBeenCalled();
+              expect(spy.mostRecentCall.args[0]).toEqual('foo');
+            });
+          });
+        });
+      });
+    });
+
+    describe('which can add a spacer', () => {
+      let toolBar;
+
+      beforeEach(() => {
+        toolBarAPI = toolBarService('specs-tool-bar');
+        toolBar = workspaceElement.querySelector('.tool-bar');
+      });
+
+      it('with no settings', () => {
+        toolBarAPI.addSpacer();
+        expect(toolBar.children.length).toBe(1);
+        expect(toolBar.firstChild.nodeName).toBe('HR');
+      });
+    });
+  });
+
+  describe('when tool-bar:toggle is triggered', () => {
+    it('hides or shows the tool bar', () => {
+      atom.commands.dispatch(workspaceElement, 'tool-bar:toggle');
+      expect(workspaceElement.querySelector('.tool-bar')).toBeNull();
+      atom.commands.dispatch(workspaceElement, 'tool-bar:toggle');
+      expect(workspaceElement.querySelectorAll('.tool-bar').length).toBe(1);
+    });
+  });
+
+  describe('when tool-bar position is changed', () => {
+    let headerPanelElement;
+    let topPanelElement;
+    let rightPanelElement;
+    let footerPanelElement;
+    let bottomPanelElement;
+    let leftPanelElement;
+
+    beforeEach(() => {
+      headerPanelElement = atom.views.getView(atom.workspace.panelContainers.header);
+      topPanelElement = atom.views.getView(atom.workspace.panelContainers.top);
+      rightPanelElement = atom.views.getView(atom.workspace.panelContainers.right);
+      footerPanelElement = atom.views.getView(atom.workspace.panelContainers.footer);
+      bottomPanelElement = atom.views.getView(atom.workspace.panelContainers.bottom);
+      leftPanelElement = atom.views.getView(atom.workspace.panelContainers.left);
+    });
+
+    if (supportFullWidth) {
+      describe('by triggering tool-bar:position-top', () => {
+        it('adds the tool bar view to header pane', () => {
+          atom.commands.dispatch(workspaceElement, 'tool-bar:position-top');
+          atom.config.set('tool-bar.fullWidth', true);
+          expect(headerPanelElement.querySelectorAll('.tool-bar').length).toBe(1);
+          expect(topPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(rightPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(footerPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(leftPanelElement.querySelector('.tool-bar')).toBeNull();
+        });
+      });
+    }
+
+    describe('by triggering tool-bar:position-top with full width disabled', () => {
+      it('adds the tool bar view to top pane', () => {
+        atom.commands.dispatch(workspaceElement, 'tool-bar:position-top');
+        atom.config.set('tool-bar.fullWidth', false);
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(topPanelElement.querySelectorAll('.tool-bar').length).toBe(1);
+        expect(rightPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(leftPanelElement.querySelector('.tool-bar')).toBeNull();
+      });
+    });
+
+    describe('by triggering tool-bar:position-right', () => {
+      it('adds the tool bar view to right pane', () => {
+        atom.commands.dispatch(workspaceElement, 'tool-bar:position-right');
+        atom.config.set('tool-bar.fullWidth', true);
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(topPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(rightPanelElement.querySelectorAll('.tool-bar').length).toBe(1);
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(leftPanelElement.querySelector('.tool-bar')).toBeNull();
+      });
+    });
+
+    if (supportFullWidth) {
+      describe('by triggering tool-bar:position-bottom', () => {
+        it('adds the tool bar view to footer pane', () => {
+          atom.commands.dispatch(workspaceElement, 'tool-bar:position-bottom');
+          atom.config.set('tool-bar.fullWidth', true);
+          expect(headerPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(topPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(rightPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(footerPanelElement.querySelectorAll('.tool-bar').length).toBe(1);
+          expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull();
+          expect(leftPanelElement.querySelector('.tool-bar')).toBeNull();
+        });
+      });
+    }
+
+    describe('by triggering tool-bar:position-bottom with full width disabled', () => {
+      it('adds the tool bar view to bottom pane', () => {
+        atom.commands.dispatch(workspaceElement, 'tool-bar:position-bottom');
+        atom.config.set('tool-bar.fullWidth', false);
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(topPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(rightPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(bottomPanelElement.querySelectorAll('.tool-bar').length).toBe(1);
+        expect(leftPanelElement.querySelector('.tool-bar')).toBeNull();
+      });
+    });
+
+    describe('by triggering tool-bar:position-left', () => {
+      it('adds the tool bar view to left pane', () => {
+        atom.commands.dispatch(workspaceElement, 'tool-bar:position-left');
+        atom.config.set('tool-bar.fullWidth', true);
+        expect(headerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(topPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(rightPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(footerPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(bottomPanelElement.querySelector('.tool-bar')).toBeNull();
+        expect(leftPanelElement.querySelectorAll('.tool-bar').length).toBe(1);
+      });
+    });
+  });
+});

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -335,7 +335,7 @@ describe('Tool Bar package', () => {
           const clickSpy = jasmine.createSpy();
           toolBar.onclick = clickSpy;
           const button = toolBarAPI.addButton({});
-          button.click();
+          button.element.click();
           expect(clickSpy).not.toHaveBeenCalled();
         });
 

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -333,7 +333,7 @@ describe('Tool Bar package', () => {
       describe('by clicking', () => {
         it('stops event bubbling', () => {
           const clickSpy = jasmine.createSpy();
-          toolBar.onclick = clickSpy;
+          toolBar.addEventListener('click', clickSpy);
           const button = toolBarAPI.addButton({});
           button.element.click();
           expect(clickSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
This is a pretty big breaking change. In [Nuclide](https://github.com/facebook/nuclide), we definitely assume that the return value of `addButton` is a space-pen view. I can imagine that this is the case for a lot of other people. Up to what point should this be mitigated? E.g.: should `ToolBarButtonView` fake having a property `0` so you can grab the underlying element like that?

There's a lot of room for improvement and performance now that space-pen is gone, but I'll do that in a follow-up PR. This is just a first-pass port.