### PR TITLE
Togglable buttons and new colours

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -50,12 +50,20 @@ export default class ToolBarButtonView {
     }
   }
 
+  isEnabled () {
+    return !this.element.classList.contains('disabled');
+  }
+
   setSelected (selected) {
     if (selected) {
       this.element.classList.add('selected');
     } else {
       this.element.classList.remove('selected');
     }
+  }
+
+  isSelected () {
+    return this.element.classList.contains('selected');
   }
 
   destroy () {

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -23,7 +23,7 @@ export default class ToolBarButtonView {
       );
     }
 
-    const classNames = ['btn', 'btn-default', 'tool-bar-btn'];
+    const classNames = ['btn', 'tool-bar-btn'];
     if (this.priority < 0) {
       classNames.push('tool-bar-item-align-end');
     }
@@ -34,6 +34,8 @@ export default class ToolBarButtonView {
     }
 
     this.element.classList.add(...classNames);
+
+    this.setColour(options.colour || 'default');
 
     this._onClick = this._onClick.bind(this);
     this._onMouseOver = this._onMouseOver.bind(this);
@@ -64,6 +66,12 @@ export default class ToolBarButtonView {
 
   isSelected () {
     return this.element.classList.contains('selected');
+  }
+
+  setColour (colour) {
+    this.element.classList.remove(`btn-${this.colour}`);
+    this.colour = colour
+    this.element.classList.add(`btn-${this.colour}`);
   }
 
   destroy () {

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -50,6 +50,14 @@ export default class ToolBarButtonView {
     }
   }
 
+  setSelected (selected) {
+    if (selected) {
+      this.element.classList.add('selected');
+    } else {
+      this.element.classList.remove('selected');
+    }
+  }
+
   destroy () {
     this.subscriptions.dispose();
     this.subscriptions = null;

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -11,14 +11,25 @@
   @button-border-size: 1px;
   background-color: @base-background-color;
   border: 1px solid @base-border-color;
-  color: @text-color;
   display: flex;
   justify-content: flex-start;
 
-  button.tool-bar-btn {
+  // Specificity must not be too high, or default :hover behaviour will
+  // be overridden.
+  .btn-default:not(.selected) {
     background-color: @base-background-color;
     background-image: inherit;
     border-color: @base-background-color;
+    color: @text-color;
+  }
+
+  button.tool-bar-btn {
+    &.btn-default.selected {
+      background-color: @button-background-color;
+    }
+    &:not(.btn-default) {
+      opacity: 0.75;
+    }
     cursor: pointer;
     flex: 0 0 auto;
     margin: @button-margin-size;

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -24,6 +24,10 @@
     margin: @button-margin-size;
     padding: 0;
 
+    &.selected {
+      color: @text-color-highlight;
+    }
+
     &:before {
       display: inline;
     }


### PR DESCRIPTION
This adds a simple button method which adds the `.selected` class to itself, as well as a method for marking the button as `btn-primary`, `btn-error` etc. My main use case for the latter option is for lighting up the console button as a way of notifying the user that there's new output to view.

![toolbar](https://cloud.githubusercontent.com/assets/2234614/15498021/6dc35616-2195-11e6-837d-08ff19e09adc.gif)