### PR TITLE
Added ability to add custom class names to items (both buttons and spacers) on the toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Make sure the following properties are part of your `package.json`.
 }
 ```
 
-We recommend using [Atom-Package-Deps](https://github.com/steelbrain/package-deps) 
+We recommend using [Atom-Package-Deps](https://github.com/steelbrain/package-deps)
 in your package for installing dependency packages like this package.
 
 ### Main package file
@@ -116,7 +116,8 @@ export function consumeToolBar(getToolBar) {
   toolBar.addButton({
     icon: 'octoface',
     callback: 'application:about',
-    tooltip: 'About Atom'
+    tooltip: 'About Atom',
+    classNames: ['custom-class-name']  // Optional parameter
   });
 
   // Adding spacer
@@ -154,7 +155,7 @@ export function consumeToolBar(getToolBar) {
         console.log(data);
       },
       'alt+shift': 'application:cmd-5',       // Multiple modifiers
-      'alt+ctrl+shift': 'application:cmd-6'   // All modifiers 
+      'alt+ctrl+shift': 'application:cmd-6'   // All modifiers
     },
     data: 'foo'
   });
@@ -177,7 +178,7 @@ export function consumeToolBar(getToolBar) {
 
 ## Methods
 
-### `.addButton({icon, callback, priority, tooltip, data})`
+### `.addButton({icon, callback, priority, tooltip, data, classNames})`
 
 The method `addButton` requires an object with at least the properties `icon`
 and `callback`. The `icon` can be any icon from the `iconset`. The `callback`
@@ -189,7 +190,7 @@ The remaining properties `tooltip` (default there is no tooltip),
 `iconset` (defaults to `Octicons`), `data` and `priority` (defaults `50`)
 are optional.
 
-### `.addSpacer({priority})`
+### `.addSpacer({priority, classNames})`
 
 The method `addSpacer` has only one optional property `priority` (defaults
 `50`).

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -23,7 +23,8 @@ export default class ToolBarButtonView {
       );
     }
 
-    const classNames = ['btn', 'btn-default', 'tool-bar-btn'];
+    const classNames = ['btn', 'btn-default', 'tool-bar-btn']
+      .concat(options.classNames || []);
     if (this.priority < 0) {
       classNames.push('tool-bar-item-align-end');
     }

--- a/lib/tool-bar-spacer-view.js
+++ b/lib/tool-bar-spacer-view.js
@@ -4,7 +4,8 @@ export default class ToolBarSpacerView {
   constructor (options) {
     this.element = document.createElement('hr');
     this.priority = options && options.priority;
-    const classNames = ['tool-bar-spacer'];
+    const classNames = ['tool-bar-spacer']
+      .concat(options && options.classNames || []);
     if (this.priority < 0) {
       classNames.push('tool-bar-item-align-end');
     }

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -509,7 +509,7 @@ describe('Tool Bar package', () => {
       });
 
       it ('with custom classes', () => {
-        const classNames = ['sample-classname', 'test-button'];
+        const classNames = ['sample-classname', 'test-spacer'];
         const options = {
           classNames,
         };

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -244,7 +244,7 @@ describe('Tool Bar package', () => {
         const classNames = ['sample-classname', 'test-button'];
         toolBarAPI.addButton({
           icon: 'octoface',
-          classNames,
+          classNames
         });
         expect(toolBar.firstChild.classList.contains(classNames[0])).toBeTruthy();
         expect(toolBar.firstChild.classList.contains(classNames[1])).toBeTruthy();
@@ -508,15 +508,15 @@ describe('Tool Bar package', () => {
         expect(toolBar.firstChild.nodeName).toBe('HR');
       });
 
-      it ('with custom classes', () => {
+      it('with custom classes', () => {
         const classNames = ['sample-classname', 'test-spacer'];
         const options = {
-          classNames,
+          classNames
         };
         toolBarAPI.addSpacer(options);
         expect(toolBar.firstChild.classList.contains(classNames[0])).toBeTruthy();
         expect(toolBar.firstChild.classList.contains(classNames[1])).toBeTruthy();
-      })
+      });
     });
   });
 

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -240,6 +240,16 @@ describe('Tool Bar package', () => {
         expect(document.activeElement).toBe(previouslyFocusedElement);
       });
 
+      it('with custom classes', () => {
+        const classNames = ['sample-classname', 'test-button'];
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          classNames,
+        });
+        expect(toolBar.firstChild.classList.contains(classNames[0])).toBeTruthy();
+        expect(toolBar.firstChild.classList.contains(classNames[1])).toBeTruthy();
+      });
+
       describe('using priority setting', () => {
         it('works with default values', () => {
           toolBarAPI.addButton({
@@ -497,6 +507,16 @@ describe('Tool Bar package', () => {
         expect(toolBar.children.length).toBe(1);
         expect(toolBar.firstChild.nodeName).toBe('HR');
       });
+
+      it ('with custom classes', () => {
+        const classNames = ['sample-classname', 'test-button'];
+        const options = {
+          classNames,
+        };
+        toolBarAPI.addSpacer(options);
+        expect(toolBar.firstChild.classList.contains(classNames[0])).toBeTruthy();
+        expect(toolBar.firstChild.classList.contains(classNames[1])).toBeTruthy();
+      })
     });
   });
 


### PR DESCRIPTION
I noticed that there was no way to add custom classes to buttons and spacers on the toolbar. While not essential for spacers, when there are two buttons with the same icon in the toolbar (or another item that shares the same octicon elsewhere on the webpage), it becomes difficult to consistently distinguish which one is which.

This diff adds the ability to query the DOM using `document.querySelector` or the like and identify a unique element by class name (instead of depending on the class name provided by the octicon).

Tests were added to test this feature -- existing tests already handle the case when `.classNames` is missing from the `options` parameter.

Additionally, I updated the README to reflect the usage of this feature.