### PR TITLE
Full-width is the new standard for the status-bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ tries to follow the [Keep a CHANGELOG](http://keepachangelog.com) convention.
 
 ## [vNext](https://github.com/suda/tool-bar/compare/v1.0.0...master) - Unreleased
 
-*   ...
+*   :art: Full-width is the new standard for the status-bar This restores bottom
+    border for vertical tool-bars with the One theme. Closes [#157](https://github.com/suda/tool-bar/issues/157)
 
 ## [v1.0.0](https://github.com/suda/tool-bar/compare/v0.4.0...v1.0.0) - 2016-07-03
 

--- a/styles/theme-one-dark-ui.less
+++ b/styles/theme-one-dark-ui.less
@@ -9,7 +9,6 @@
     border-top: 0 none;
   }
   .tool-bar-right {
-    border-bottom: 0 none;
     border-right: 0 none;
     border-top: 0 none;
   }
@@ -17,7 +16,6 @@
     border-top: 0 none;
   }
   .tool-bar-left {
-    border-bottom: 0 none;
     border-left: 0 none;
     border-top: 0 none;
   }

--- a/styles/theme-one-light-ui.less
+++ b/styles/theme-one-light-ui.less
@@ -3,7 +3,6 @@
     border-top: 0 none;
   }
   .tool-bar-right {
-    border-bottom: 0 none;
     border-right: 0 none;
     border-top: 0 none;
   }
@@ -11,7 +10,6 @@
     border-top: 0 none;
   }
   .tool-bar-left {
-    border-bottom: 0 none;
     border-left: 0 none;
     border-top: 0 none;
   }


### PR DESCRIPTION
This restores bottom-border for vertical tool-bars with the One theme. Closes #157