### PR TITLE
Update One themes

### DIFF
--- a/styles/theme-one-dark-ui.less
+++ b/styles/theme-one-dark-ui.less
@@ -5,18 +5,4 @@
       background-image: inherit;
     }
   }
-  .tool-bar-top {
-    border-top: 0 none;
-  }
-  .tool-bar-right {
-    border-right: 0 none;
-    border-top: 0 none;
-  }
-  .tool-bar-bottom {
-    border-top: 0 none;
-  }
-  .tool-bar-left {
-    border-left: 0 none;
-    border-top: 0 none;
-  }
 }

--- a/styles/theme-one-light-ui.less
+++ b/styles/theme-one-light-ui.less
@@ -1,16 +1,2 @@
 .theme-one-light-ui {
-  .tool-bar-top {
-    border-top: 0 none;
-  }
-  .tool-bar-right {
-    border-right: 0 none;
-    border-top: 0 none;
-  }
-  .tool-bar-bottom {
-    border-top: 0 none;
-  }
-  .tool-bar-left {
-    border-left: 0 none;
-    border-top: 0 none;
-  }
 }

--- a/styles/theme-one-light-ui.less
+++ b/styles/theme-one-light-ui.less
@@ -1,2 +1,8 @@
 .theme-one-light-ui {
+  .tool-bar button.tool-bar-btn.disabled {
+    &:hover, &:focus {
+      background-color: inherit;
+      background-image: inherit;
+    }
+  }
 }


### PR DESCRIPTION
The One themes now handle the borders/padding of panels, so tool-bar doesn't have to worry about it. Thus this PR removes them. Ref:

- https://github.com/atom/one-light-ui/pull/69
- https://github.com/atom/one-dark-ui/pull/162

Also, it adds the same `.disabled` styles from One dark to One light.

The changes will land in Atom `1.11`.