### PR TITLE
Moved menu from Packages to View

### DIFF
--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -180,26 +180,7 @@ export default class ToolBarView {
     }
     this.element.classList.add(...classNames);
 
-    this.updateMenu(position);
     this.drawGutter();
-  }
-
-  updateMenu (position) {
-    const packagesMenu = atom.menu.template.find(({label}) =>
-      (label === 'Packages' || label === '&Packages'));
-
-    const toolBarMenu = packagesMenu && packagesMenu.submenu.find(({label}) =>
-      (label === 'Tool Bar' || label === '&Tool Bar'));
-
-    const positionsMenu = toolBarMenu && toolBarMenu.submenu.find(({label}) =>
-      (label === 'Position' || label === '&Position'));
-
-    const positionMenu = positionMenu && positionsMenu.submenu.find(({label}) =>
-      label === position);
-
-    if (positionMenu) {
-      positionMenu.checked = true;
-    }
   }
 
   drawGutter () {

--- a/menus/tool-bar.cson
+++ b/menus/tool-bar.cson
@@ -1,22 +1,8 @@
 menu: [
   {
-    label: 'Packages'
+    label: 'View'
     submenu: [
-      {
-        label: '&Tool Bar'
-        submenu: [
-          { label: '&Toggle', command: 'tool-bar:toggle' }
-          {
-            label: '&Position',
-            submenu: [
-              { label: 'Top', command: 'tool-bar:position-top', type: 'radio' }
-              { label: 'Right', command: 'tool-bar:position-right', type: 'radio' }
-              { label: 'Bottom', command: 'tool-bar:position-bottom', type: 'radio' }
-              { label: 'Left', command: 'tool-bar:position-left', type: 'radio' }
-            ]
-          }
-        ]
-      }
+      { label: 'Toggle Tool Bar', command: 'tool-bar:toggle' }
     ]
   }
 ],


### PR DESCRIPTION
As the Tool Bar is part of the visible UI of Atom, I felt like we should move the toggle command to the View menu of Atom.
![atom-tool-bar](https://cloud.githubusercontent.com/assets/55841/18417989/529d1c78-783e-11e6-8039-e381e0d27a9e.png)

This PR also removes the Tool Bar Position menu, as it's already available as context-menu on the Tool Bar and as setting.

By moving the Toggle Tool Bar menu-item, I also removed the `&` (Ampersand) from the label to fix https://github.com/suda/tool-bar/issues/97.
