### PR TITLE
Debounce `drawGutter` with `requestAnimationFrame`

### DIFF
--- a/lib/raf-debounce.js
+++ b/lib/raf-debounce.js
@@ -1,0 +1,35 @@
+'use babel';
+
+export default function rafDebounce (fn) {
+  let args;
+  let context;
+  let requestID;
+
+  function later () {
+    fn.apply(context, args);
+    args = context = requestID = null;
+  }
+
+  function debounced () {
+    if (fn == null) {
+      throw new Error('raf debounced function is already disposed.');
+    }
+    args = arguments;
+    context = this;
+    if (requestID) {
+      window.cancelAnimationFrame(requestID);
+    }
+    requestID = window.requestAnimationFrame(later);
+  }
+
+  debounced.dispose = () => {
+    if (fn != null) {
+      if (requestID) {
+        window.cancelAnimationFrame(requestID);
+      }
+      args = context = requestID = fn = null;
+    }
+  };
+
+  return debounced;
+}

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import {CompositeDisposable, Emitter} from 'atom';
+import rafDebounce from './raf-debounce';
 
 const supportFullWidth = typeof atom.workspace.addHeaderPanel === 'function';
 
@@ -64,7 +65,8 @@ export default class ToolBarView {
       this.show();
     }
 
-    this.drawGutter = this.drawGutter.bind(this);
+    this.drawGutter = rafDebounce(this.drawGutter.bind(this));
+    this.subscriptions.add(this.drawGutter);
 
     this.element.addEventListener('scroll', this.drawGutter);
     window.addEventListener('resize', this.drawGutter);


### PR DESCRIPTION
See https://github.com/suda/tool-bar/pull/163#issuecomment-250292271.

This is a first step towards batching DOM updates. Although this is a huge improvement over the current setup, it can be done much better. Right now, all the work is still happening upfront it's just debounced.

From: https://github.com/facebook/nuclide

Before:

![before](https://cloud.githubusercontent.com/assets/830952/18972035/886a6cc2-8665-11e6-9e1d-62c338a3bb34.png)

After:

![after](https://cloud.githubusercontent.com/assets/830952/18972039/8be185f2-8665-11e6-97b2-9835e10bc051.png)

This takes init time from 127ms to 55ms.

cc: @jerone