### PR TITLE
Limit engines to >=1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "remark-lint": "^3.0.0"
   },
   "engines": {
-    "atom": ">=1.0.0"
+    "atom": ">=1.6.0"
   },
   "providedServices": {
     "tool-bar": {


### PR DESCRIPTION
This makes sense now since #165 assumes that `atom.workspace.addHeaderPanel` exists. This will prevent people on old Atom versions from accidentally updating/installing tool-bar. Though, given how aggressive Atom's autoupdate is, nobody is probably using anything but the latest.