### PR TITLE
Display keybinding in the tooltip

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -15,11 +15,12 @@ export default class ToolBarButtonView {
     this.group = group;
 
     if (options.tooltip) {
-      this.element.title = options.tooltip;
+      const callback = this.options.callback;
       this.subscriptions.add(
         atom.tooltips.add(this.element, {
           title: options.tooltip,
-          placement: getTooltipPlacement
+          placement: getTooltipPlacement,
+          keyBindingCommand: typeof callback === 'string' ? callback : null
         })
       );
     }

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -1,6 +1,7 @@
 'use babel';
 
 /* eslint-env browser */
+/* global advanceClock */
 
 function getGlyph (elm) {
   return window.getComputedStyle(elm, ':before')
@@ -95,7 +96,13 @@ describe('Tool Bar package', () => {
           tooltip: 'About Atom'
         });
         expect(toolBar.children.length).toBe(1);
-        expect(toolBar.firstChild.dataset.originalTitle).toBe('About Atom');
+        const element = toolBar.firstChild;
+        element.dispatchEvent(new CustomEvent('mouseenter', {bubbles: false}));
+        element.dispatchEvent(new CustomEvent('mouseover', {bubbles: true}));
+        advanceClock(1000);
+        const tooltip = document.body.querySelector('.tooltip');
+        expect(tooltip).not.toBeNull();
+        expect(tooltip.outerHTML.indexOf('About Atom')).not.toBe(-1);
       });
 
       it('using default iconset', () => {


### PR DESCRIPTION
A little known feature of Atom tooltip is that it supports displaying the keybinding directly inside of the tooltip if you pass a `keyBindingCommand` value as the atom command.

In Nuclide we're already giving the command so I figured it would be cool to display the keybinding as well :)

Let me know if it's something you'd consider! Thanks

Test Plan:

Open Nuclide, mouse over all the buttons, make sure you can see the keybinding for it.
![image](https://cloud.githubusercontent.com/assets/197597/19914658/a0c92560-a069-11e6-9663-5af5a9cf7dc7.png)
