### PR TITLE
Add support for selected buttons.

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -51,6 +51,18 @@ export default class ToolBarButtonView {
     }
   }
 
+  setSelected (selected) {
+    if (selected) {
+      this.element.classList.add('selected');
+    } else {
+      this.element.classList.remove('selected');
+    }
+  }
+
+  getSelected () {
+    return this.element.classList.contains('selected');
+  }
+
   destroy () {
     this.subscriptions.dispose();
     this.subscriptions = null;

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -32,6 +32,10 @@
       border-color: @button-border-color;
       outline: none;
     }
+
+    .selected {
+      color: @button-text-color-selected;
+    }
   }
 
   &.tool-bar-horizontal .tool-bar-btn:not(.tool-bar-item-align-end) + .tool-bar-btn {


### PR DESCRIPTION
This allows consumers to implement toggle buttons or radio groups.  See #43 

The logic of toggling the selection is left to the consumer.  For a most basic toggle button:
```js
export default {
  toolBar: null,
  toggleButton: null,

  consumeToolBar(getToolBar) {
    this.toolBar = getToolBar('my-toolbar');
    this.toggleButton = this.toolBar.addButton({
      icon: 'plug',
      callback: () => this.toggleButton.setSelected(!this.toggleButton.getSelected())
    });
}
```
