### PR TITLE
Add option for custom elements

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -28,10 +28,22 @@ export default class ToolBarButtonView {
     if (this.priority < 0) {
       classNames.push('tool-bar-item-align-end');
     }
-    if (options.iconset) {
-      classNames.push(options.iconset, `${options.iconset}-${options.icon}`);
+    if (options.element) {
+      var elements = options.element.getElementsByTagName('svg');
+      for (var i = 0; i < elements.length; i++) {
+        var element = elements[i];
+        element.style.fill = 'currentColor';
+        element.style.width = '18px';
+        element.style.height = '24px';
+        element.classList.add('octicons');
+      }
+      this.element.appendChild(options.element);
     } else {
-      classNames.push(`icon-${options.icon}`);
+      if (options.iconset && options.iconset !== 'octicons') {
+        classNames.push(options.iconset, `${options.iconset}-${options.icon}`);
+      } else {
+        classNames.push(`icon-${options.icon}`);
+      }
     }
 
     this.element.classList.add(...classNames);


### PR DESCRIPTION
Adds ability to add whatever elements you would like to the button.
Really had only intended it for custom svg, but could work for whatever I guess.

Usage: 
![image](https://cloud.githubusercontent.com/assets/10274309/25454635/0aa0e660-2a82-11e7-9276-fe5043295b45.png)

SVG's size + colour is automatically set
