### PR TITLE
Add Touch Bar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ On which edge of the editor should the tool bar appear. Possible options:
 
 When on top/bottom, expand to full window width.
 
+### Use TouchBar
+
+If your computer is equipped with a TouchBar (only Apple MacBook Pro series
+currently) it can display up to seven tool bar buttons there.
+
 ## Plugins
 
 *   [Flex Tool Bar](https://atom.io/packages/flex-tool-bar)

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -11,6 +11,7 @@ module.exports = class ToolBarButtonView {
     this.priority = options.priority;
     this.options = options;
     this.group = group;
+    this.enabled = true;
 
     if (options.tooltip) {
       const callback = this.options.callback;
@@ -48,6 +49,7 @@ module.exports = class ToolBarButtonView {
     } else {
       this.element.classList.add('disabled');
     }
+    this.enabled = enabled;
   }
 
   destroy () {
@@ -68,8 +70,10 @@ module.exports = class ToolBarButtonView {
     if (this.element && !this.element.classList.contains('disabled')) {
       executeCallback(this.options, e);
     }
-    e.preventDefault();
-    e.stopPropagation();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
   }
 
   _onMouseOver (e) {

--- a/lib/tool-bar-manager.js
+++ b/lib/tool-bar-manager.js
@@ -2,14 +2,16 @@ const ToolBarButtonView = require('./tool-bar-button-view');
 const ToolBarSpacerView = require('./tool-bar-spacer-view');
 
 module.exports = class ToolBarManager {
-  constructor (group, toolBarView) {
+  constructor (group, toolBarView, touchBarManager) {
     this.group = group;
     this.toolBarView = toolBarView;
+    this.touchBarManager = touchBarManager;
   }
 
   addButton (options) {
     const button = new ToolBarButtonView(options, this.group);
     this.toolBarView.addItem(button);
+    this.touchBarManager.addButton(button);
     return button;
   }
 

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -1,19 +1,24 @@
 const ToolBarManager = require('./tool-bar-manager');
 const ToolBarView = require('./tool-bar-view');
+const TouchBarManager = require('./touch-bar-manager');
 
 let toolBarView = null;
+let touchBarManager = null;
 
 exports.activate = function () {
   toolBarView = new ToolBarView();
+  touchBarManager = new TouchBarManager();
 };
 
 exports.deactivate = function () {
   toolBarView.destroy();
   toolBarView = null;
+  touchBarManager.destroy();
+  touchBarManager = null;
 };
 
 exports.provideToolBar = function provideToolBar () {
-  return (group) => new ToolBarManager(group, toolBarView);
+  return (group) => new ToolBarManager(group, toolBarView, touchBarManager);
 };
 
 exports.config = {
@@ -38,5 +43,12 @@ exports.config = {
     type: 'boolean',
     default: true,
     order: 4
+  },
+  useTouchBar: {
+    title: 'Use TouchBar',
+    description: 'Show seven first tool bar buttons in the TouchBar',
+    type: 'boolean',
+    default: true,
+    order: 5
   }
 };

--- a/lib/touch-bar-manager.js
+++ b/lib/touch-bar-manager.js
@@ -1,0 +1,68 @@
+const {TouchBar, nativeImage} = require('electron').remote;
+const {TouchBarButton} = TouchBar;
+
+module.exports = class TouchBarManager {
+  constructor () {
+    this.buttons = [];
+  }
+
+  destroy () {
+    this.buttons = [];
+    this.update();
+  }
+
+  addButton (button) {
+    this._renderButton(button).then(icon => {
+      const touchButton = new TouchBarButton({
+        icon: icon,
+        click: button._onClick.bind(button)
+      });
+
+      this.buttons.push({
+        priority: button.priority ? button.priority : 0,
+        touchButton
+      });
+
+      this.update();
+    });
+  }
+
+  update () {
+    if (!atom.config.get('tool-bar.useTouchBar')) return;
+
+    const items = this.buttons
+      .sort((a, b) => a.priority - b.priority)
+      .map(button => button.touchButton);
+    let touchBar = new TouchBar(items);
+    atom.getCurrentWindow().setTouchBar(touchBar);
+  }
+
+  _renderButton (button) {
+    return document.fonts.ready.then(() => {
+      const iconSize = 44 * 2;
+      const iconStyle = window.getComputedStyle(button.element, ':before');
+      const iconText = iconStyle.content.replace(/["']/g, '');
+
+      let canvas = document.createElement('canvas');
+      canvas.width = 60 * 2;
+      canvas.height = 60 * 2;
+      let context = canvas.getContext('2d');
+      context.textAlign = 'center';
+      context.textBaseline = 'top';
+
+      context.fillStyle = button.enabled ? '#fff' : '#aaa';
+      context.font = `${iconSize}px ${iconStyle.fontFamily}`;
+      context.fillText(iconText, canvas.width / 2, (canvas.height - iconSize) / 2);
+
+      const image = nativeImage.createEmpty();
+      image.addRepresentation({
+        dataURL: canvas.toDataURL(),
+        scaleFactor: 2.0,
+        width: 44,
+        height: 44
+      });
+
+      return image;
+    });
+  }
+};


### PR DESCRIPTION
![2018-01-05 23 06 05](https://user-images.githubusercontent.com/25722/34650030-443332a0-f3ba-11e7-8d64-8f402d6b2c75.jpg)

This PR adds support for MacBook Pro Touch Bar. Due to Touch Bar limitations, it can only display seven buttons but that should be enough for most cases.