### PR TITLE
allow tooltip to be an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ The remaining properties `tooltip` (default there is no tooltip),
 `iconset` (defaults to `Octicons`), `data` and `priority` (defaults `50`)
 are optional.
 
+The `tooltip` option may be a string or an object that is passed to Atom's
+[TooltipManager](https://atom.io/docs/api/latest/TooltipManager#instance-add)
+
 The return value of this method shares another method called
 `setEnabled(enabled)` to enable or disable the button.
 

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -15,12 +15,26 @@ module.exports = class ToolBarButtonView {
 
     if (options.tooltip) {
       const callback = this.options.callback;
+
+      let tooltip = {};
+      if (typeof options.tooltip === 'string') {
+        tooltip = {
+          title: options.tooltip
+        };
+      } else {
+        tooltip = options.tooltip;
+      }
+
+      if (!tooltip.hasOwnProperty('placement')) {
+        tooltip.placement = getTooltipPlacement;
+      }
+
+      if (!tooltip.hasOwnProperty('keyBindingCommand')) {
+        tooltip.keyBindingCommand = typeof callback === 'string' ? callback : null;
+      }
+
       this.subscriptions.add(
-        atom.tooltips.add(this.element, {
-          title: options.tooltip,
-          placement: getTooltipPlacement,
-          keyBindingCommand: typeof callback === 'string' ? callback : null
-        })
+        atom.tooltips.add(this.element, tooltip)
       );
     }
 

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -105,6 +105,25 @@ describe('Tool Bar package', () => {
         expect(tooltip.outerHTML.indexOf('About Atom')).not.toBe(-1);
       });
 
+      it('with tooltip object', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about',
+          tooltip: {
+            html: false,
+            title: '<h1>About Atom</h1>'
+          }
+        });
+        expect(toolBar.children.length).toBe(1);
+        const element = toolBar.firstChild;
+        element.dispatchEvent(new CustomEvent('mouseenter', {bubbles: false}));
+        element.dispatchEvent(new CustomEvent('mouseover', {bubbles: true}));
+        advanceClock(1000);
+        const tooltip = document.body.querySelector('.tooltip');
+        expect(tooltip).not.toBeNull();
+        expect(tooltip.outerHTML.indexOf('&lt;h1&gt;About Atom&lt;/h1&gt;')).not.toBe(-1);
+      });
+
       it('using default iconset', () => {
         jasmine.attachToDOM(toolBar);
         toolBarAPI.addButton({


### PR DESCRIPTION
Allows the tooltip option to be a string or object

fixes #182 
fixes https://github.com/cakecatz/flex-toolbar/issues/96