### PR TITLE
Text/html button

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ export function consumeToolBar(getToolBar) {
 The method `addButton` requires an object with at least the property `callback`. The
 `callback` must be an Atom command string, a custom callback function or an
 object where the keys are key modifiers (`alt`, `ctrl` or `shift`) and the
-values are commands or custom function (see [example](#example)).
+values are commands or custom functions (see [example](#example)).
 
 The remaining properties
 `tooltip` (default there is no tooltip),

--- a/README.md
+++ b/README.md
@@ -178,6 +178,27 @@ export function consumeToolBar(getToolBar) {
     priority: 10
   });
 
+  // Adding text button
+  toolBar.addButton({
+    text: 'hello',
+    callback: 'application:about'
+  });
+
+  // Text buttons can also have an icon
+  toolBar.addButton({
+    icon: 'octoface',
+    text: 'hello',
+    callback: 'application:about'
+  });
+
+  // Text buttons can be html
+  toolBar.addButton({
+    icon: 'octoface',
+    text: '<b>BIG</b> button',
+    html: true,
+    callback: 'application:about'
+  });
+
   // Cleaning up when tool bar is deactivated
   toolBar.onDidDestroy(() => {
     this.toolBar = null;
@@ -188,16 +209,21 @@ export function consumeToolBar(getToolBar) {
 
 ## Methods
 
-### `.addButton({icon, callback, priority, tooltip, data})`
+### `.addButton({icon, iconset, text, html, callback, priority, tooltip, data})`
 
-The method `addButton` requires an object with at least the properties `icon`
-and `callback`. The `icon` can be any single icon from the `iconset`. The
-`callback` must be an Atom command string, an custom callback function or an
+The method `addButton` requires an object with at least the property `callback`. The
+`callback` must be an Atom command string, a custom callback function or an
 object where the keys are key modifiers (`alt`, `ctrl` or `shift`) and the
 values are commands or custom function (see [example](#example)).
 
-The remaining properties `tooltip` (default there is no tooltip),
-`iconset` (defaults to `Octicons`), `data` and `priority` (defaults `50`)
+The remaining properties
+`tooltip` (default there is no tooltip),
+`text` (default there is no text),
+`html` (default `false`),
+`icon` (default there is no icon),
+`iconset` (defaults to `Octicons`),
+`data`, and
+`priority` (defaults `50`)
 are optional.
 
 The `tooltip` option may be a `string` or an `object` that is passed to Atom's

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -48,6 +48,14 @@ module.exports = class ToolBarButtonView {
       classNames.push(`icon-${options.icon}`);
     }
 
+    if (options.text) {
+      if (options.html) {
+        this.element.innerHTML = options.text;
+      } else {
+        this.element.textContent = options.text;
+      }
+    }
+
     this.element.classList.add(...classNames);
 
     this._onClick = this._onClick.bind(this);

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -42,10 +42,12 @@ module.exports = class ToolBarButtonView {
     if (this.priority < 0) {
       classNames.push('tool-bar-item-align-end');
     }
-    if (options.iconset) {
-      classNames.push(options.iconset, `${options.iconset}-${options.icon}`);
-    } else {
-      classNames.push(`icon-${options.icon}`);
+    if (options.icon) {
+      if (options.iconset) {
+        classNames.push(options.iconset, `${options.iconset}-${options.icon}`);
+      } else {
+        classNames.push(`icon-${options.icon}`);
+      }
     }
 
     if (options.text) {

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -124,6 +124,29 @@ describe('Tool Bar package', () => {
         expect(tooltip.outerHTML.indexOf('&lt;h1&gt;About Atom&lt;/h1&gt;')).not.toBe(-1);
       });
 
+      it('with text', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about',
+          text: '<span>text</span>'
+        });
+        expect(toolBar.children.length).toBe(1);
+        const element = toolBar.firstChild;
+        expect(element.outerHTML.indexOf('&lt;span&gt;text&lt;/span&gt;')).not.toBe(-1);
+      });
+
+      it('with html', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about',
+          text: '<span>text</span>',
+          html: true
+        });
+        expect(toolBar.children.length).toBe(1);
+        const element = toolBar.firstChild;
+        expect(element.outerHTML.indexOf('<span>text</span>')).not.toBe(-1);
+      });
+
       it('using default iconset', () => {
         jasmine.attachToDOM(toolBar);
         toolBarAPI.addButton({

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -133,10 +133,19 @@
 
     .tool-bar-btn {
       height: @size + (@button-border-size * 2);
-      width: @size + (@button-border-size * 2);
+      min-width: @size + (@button-border-size * 2);
       &:before {
         font-size: @size / 2;
         line-height: @size;
+      }
+
+      &:not(:empty) {
+        font-size: @size / 2;
+        line-height: @size;
+        padding: 0 @size / 4;
+        &:before {
+          padding-right: @size / 4;
+        }
       }
     }
 


### PR DESCRIPTION
Add text and html options

html is a boolean attribute to allow the text to be inserted as html

I also made the icon optional to allow for just text buttons

fixes #215 
fixes https://github.com/cakecatz/flex-toolbar/issues/111
fixes https://github.com/cakecatz/flex-toolbar/issues/120

```js
  // Adding text button
  toolBar.addButton({
    text: 'hello',
    callback: 'application:about'
  });

  // Text buttons can also have an icon
  toolBar.addButton({
    icon: 'octoface',
    text: 'hello',
    callback: 'application:about'
  });

  // Text buttons can be html
  toolBar.addButton({
    icon: 'octoface',
    text: '<b>BIG</b> button',
    html: true,
    callback: 'application:about'
  });
```