### PR TITLE
set this as button in callback function

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -94,7 +94,7 @@ module.exports = class ToolBarButtonView {
   _onClick (e) {
     getPrevFocusedElm().focus();
     if (this.element && !this.element.classList.contains('disabled')) {
-      executeCallback(this.options, e);
+      executeCallback(this, e);
     }
     if (e.preventDefault) {
       e.preventDefault();
@@ -127,7 +127,8 @@ function getTooltipPlacement () {
        : null;
 }
 
-function executeCallback ({callback, data}, e) {
+function executeCallback (buttonView, e) {
+  let {callback, data} = buttonView.options;
   if (typeof callback === 'object' && !Array.isArray(callback) && callback) {
     callback = getCallbackModifier(callback, e);
   }
@@ -138,7 +139,7 @@ function executeCallback ({callback, data}, e) {
       atom.commands.dispatch(getPrevFocusedElm(), callback[i]);
     }
   } else if (typeof callback === 'function') {
-    callback(data, getPrevFocusedElm());
+    callback.call(buttonView, data, getPrevFocusedElm());
   }
 }
 

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -246,13 +246,14 @@ describe('Tool Bar package', () => {
 
       it('clicking button with function callback', () => {
         const spy = jasmine.createSpy();
-        toolBarAPI.addButton({
+        const button = toolBarAPI.addButton({
           icon: 'octoface',
           callback: spy
         });
         jasmine.attachToDOM(toolBar);
         toolBar.firstChild.click();
         expect(spy).toHaveBeenCalled();
+        expect(spy.mostRecentCall.object).toBe(button);
       });
 
       it('clicking button with function callback containing data', () => {


### PR DESCRIPTION
This will allow the user to use `this.getSelected()` in the function callback