### PR TITLE
Avoid taking focus when clicking buttons

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -1,7 +1,5 @@
 const {CompositeDisposable} = require('atom');
 
-let prevFocusedElm = null;
-
 module.exports = class ToolBarButtonView {
 
   constructor (options, group) {
@@ -60,11 +58,11 @@ module.exports = class ToolBarButtonView {
 
     this.element.classList.add(...classNames);
 
+    this._onMouseDown = this._onMouseDown.bind(this);
     this._onClick = this._onClick.bind(this);
-    this._onMouseOver = this._onMouseOver.bind(this);
 
+    this.element.addEventListener('mousedown', this._onMouseDown);
     this.element.addEventListener('click', this._onClick);
-    this.element.addEventListener('mouseover', this._onMouseOver);
   }
 
   setEnabled (enabled) {
@@ -97,12 +95,15 @@ module.exports = class ToolBarButtonView {
     }
 
     this.element.removeEventListener('click', this._onClick);
-    this.element.removeEventListener('mouseover', this._onMouseOver);
     this.element = null;
   }
 
+  _onMouseDown (e) {
+    // Avoid taking focus so we can dispatch Atom commands with the correct target.
+    e.preventDefault();
+  }
+
   _onClick (e) {
-    getPrevFocusedElm().focus();
     if (this.element && !this.element.classList.contains('disabled')) {
       this.executeCallback(e);
     }
@@ -112,18 +113,12 @@ module.exports = class ToolBarButtonView {
     }
   }
 
-  _onMouseOver (e) {
-    if (!document.activeElement.classList.contains('tool-bar-btn')) {
-      prevFocusedElm = document.activeElement;
-    }
-  }
-
   executeCallback (e) {
     let {callback, data} = this.options;
     if (typeof callback === 'object' && !Array.isArray(callback) && callback) {
       callback = getCallbackModifier(callback, e);
     }
-    const target = getPrevFocusedElm();
+    const target = document.activeElement;
     if (typeof callback === 'string') {
       atom.commands.dispatch(target, callback);
     } else if (Array.isArray(callback)) {
@@ -135,15 +130,6 @@ module.exports = class ToolBarButtonView {
     }
   }
 };
-
-function getPrevFocusedElm () {
-  const workspaceView = atom.views.getView(atom.workspace);
-  if (workspaceView.contains(prevFocusedElm)) {
-    return prevFocusedElm;
-  } else {
-    return workspaceView;
-  }
-}
 
 function getTooltipPlacement () {
   const toolbarPosition = atom.config.get('tool-bar.position');

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -104,7 +104,7 @@ module.exports = class ToolBarButtonView {
   _onClick (e) {
     getPrevFocusedElm().focus();
     if (this.element && !this.element.classList.contains('disabled')) {
-      executeCallback(this, e);
+      this.executeCallback(e);
     }
     if (e.preventDefault) {
       e.preventDefault();
@@ -115,6 +115,22 @@ module.exports = class ToolBarButtonView {
   _onMouseOver (e) {
     if (!document.activeElement.classList.contains('tool-bar-btn')) {
       prevFocusedElm = document.activeElement;
+    }
+  }
+
+  executeCallback (e) {
+    let {callback, data} = this.options;
+    if (typeof callback === 'object' && !Array.isArray(callback) && callback) {
+      callback = getCallbackModifier(callback, e);
+    }
+    if (typeof callback === 'string') {
+      atom.commands.dispatch(getPrevFocusedElm(), callback);
+    } else if (Array.isArray(callback)) {
+      for (let i = 0; i < callback.length; i++) {
+        atom.commands.dispatch(getPrevFocusedElm(), callback[i]);
+      }
+    } else if (typeof callback === 'function') {
+      callback.call(this, data, getPrevFocusedElm());
     }
   }
 };
@@ -135,22 +151,6 @@ function getTooltipPlacement () {
        : toolbarPosition === 'Bottom' ? 'top'
        : toolbarPosition === 'Left' ? 'right'
        : null;
-}
-
-function executeCallback (buttonView, e) {
-  let {callback, data} = buttonView.options;
-  if (typeof callback === 'object' && !Array.isArray(callback) && callback) {
-    callback = getCallbackModifier(callback, e);
-  }
-  if (typeof callback === 'string') {
-    atom.commands.dispatch(getPrevFocusedElm(), callback);
-  } else if (Array.isArray(callback)) {
-    for (let i = 0; i < callback.length; i++) {
-      atom.commands.dispatch(getPrevFocusedElm(), callback[i]);
-    }
-  } else if (typeof callback === 'function') {
-    callback.call(buttonView, data, getPrevFocusedElm());
-  }
 }
 
 function getCallbackModifier (callback, {altKey, ctrlKey, shiftKey}) {

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -123,14 +123,15 @@ module.exports = class ToolBarButtonView {
     if (typeof callback === 'object' && !Array.isArray(callback) && callback) {
       callback = getCallbackModifier(callback, e);
     }
+    const target = getPrevFocusedElm();
     if (typeof callback === 'string') {
-      atom.commands.dispatch(getPrevFocusedElm(), callback);
+      atom.commands.dispatch(target, callback);
     } else if (Array.isArray(callback)) {
       for (let i = 0; i < callback.length; i++) {
-        atom.commands.dispatch(getPrevFocusedElm(), callback[i]);
+        atom.commands.dispatch(target, callback[i]);
       }
     } else if (typeof callback === 'function') {
-      callback.call(this, data, getPrevFocusedElm());
+      callback.call(this, data, target);
     }
   }
 };


### PR DESCRIPTION
Rather than tracking the previously focused element, don't take
focus in the first place.

This avoids a few error cases:

1. Returning focus can have unintentional side effects.
2. Theoretically focus could change between the time a user moused into
   the tool bar and when they actually clicked.

Resolves #235