### PR TITLE
Remove ineffective focus test

### DIFF
--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -291,19 +291,6 @@ describe('Tool Bar package', () => {
         expect(spy.mostRecentCall.args[0]).toEqual('foo');
       });
 
-      it('and restores focus after click', () => {
-        toolBarAPI.addButton({
-          icon: 'octoface',
-          callback: 'editor:select-line',
-          tooltip: 'Select line'
-        });
-        const previouslyFocusedElement = document.activeElement;
-        toolBar.firstChild.dispatchEvent(new Event('mouseover'));
-        toolBar.firstChild.focus();
-        toolBar.firstChild.click();
-        expect(document.activeElement).toBe(previouslyFocusedElement);
-      });
-
       describe('using priority setting', () => {
         it('works with default values', () => {
           toolBarAPI.addButton({


### PR DESCRIPTION
The tool bar is never actually added to the DOM, so the `.focus()` call
does not actually do anything.

If this test were working as expected, it should have failed on https://github.com/suda/tool-bar/pull/239.