### PR TITLE
Ensure target is within atom-workspace

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -119,7 +119,13 @@ module.exports = class ToolBarButtonView {
     if (typeof callback === 'object' && !Array.isArray(callback) && callback) {
       callback = getCallbackModifier(callback, e);
     }
-    const target = document.activeElement;
+    const workspaceView = atom.views.getView(atom.workspace);
+
+    // Ensure we don't try to dispatch on any target above `atom-workspace`.
+    const target = workspaceView.contains(document.activeElement)
+      ? document.activeElement
+      : workspaceView;
+
     if (typeof callback === 'string') {
       atom.commands.dispatch(target, callback);
     } else if (Array.isArray(callback)) {


### PR DESCRIPTION
Accidentally removed in #239.

Fixes #244

Test plan: In the console issue `document.body.focus()` click the "Upload" button that PlatformIO adds to Tool Bar. Check that the build is run.