### PR TITLE
Combine string and function callback for button view

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -131,7 +131,7 @@ module.exports = class ToolBarButtonView {
       : workspaceView;
 
     if (!Array.isArray(callback)) {
-      callback = [callback]
+      callback = [callback];
     }
 
     for (let i = 0; i < callback.length; i++) {

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -130,14 +130,16 @@ module.exports = class ToolBarButtonView {
       ? document.activeElement
       : workspaceView;
 
-    if (typeof callback === 'string') {
-      atom.commands.dispatch(target, callback);
-    } else if (Array.isArray(callback)) {
-      for (let i = 0; i < callback.length; i++) {
+    if (!Array.isArray(callback)) {
+      callback = [callback]
+    }
+
+    for (let i = 0; i < callback.length; i++) {
+      if (typeof callback[i] === 'string') {
         atom.commands.dispatch(target, callback[i]);
+      } else if (typeof callback[i] === 'function') {
+        callback[i].call(this, data, target);
       }
-    } else if (typeof callback === 'function') {
-      callback.call(this, data, target);
     }
   }
 };


### PR DESCRIPTION
# Change

The change I'm proposing allows users to specify both atom commands and function for callback when multiple callbacks are specified. So, before it was only possible to do:

```js
toolBar.addButton({
  type: "button",
  icon: "chevron-right",
  callback: ['application:cmd-1', 'application:cmd-2'],
  tooltip: "Show project"
})
``` 

But not with a command and function, like:

```js
toolBar.addButton({
  type: "button",
  icon: "chevron-right",
  callback: ['application:cmd-1', () => console.log("Hello world!")],
  tooltip: "Show project"
})
``` 

With this Pull Request that is now possible.

# Implementation

I changed the "executeCallback" function so that the user can use both strings (for atom command dispatching) and function (for whatever the user wants) when the `callback` option is set to an array.

To achieve this I convert the `callback` value to an array if it is not and then iterate over the array and perform either the dispatch or function call as it happened before.

# Testing

I did not find any tests for this function so I also didn't add a new test.