### PR TITLE
separators look better with dark themes

### DIFF
--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -47,15 +47,15 @@
 
   &.tool-bar-horizontal .tool-bar-spacer {
     border: 0 none;
-    border-left: @button-border-size solid @button-background-color;
-    border-right: @button-border-size solid @button-border-color;
+    border-left: @button-border-size solid rgba(125, 125, 125, 0.3);
+    border-right: @button-border-size solid rgba(125, 125, 125, 0.3);
     -webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,0),rgba(0,0,0,0.7),rgba(0,0,0,1),rgba(0,0,0,0.7), rgba(0,0,0,0));
     margin: @button-margin-size + 3 0;
   }
   &.tool-bar-vertical .tool-bar-spacer {
     border: 0 none;
-    border-bottom: @button-border-size solid @button-background-color;
-    border-top: @button-border-size solid @button-border-color;
+    border-bottom: @button-border-size solid rgba(125, 125, 125, 0.3);
+    border-top: @button-border-size solid rgba(125, 125, 125, 0.3);
     -webkit-mask-image: linear-gradient(to right, rgba(0,0,0,0),rgba(0,0,0,0.7),rgba(0,0,0,1),rgba(0,0,0,0.7), rgba(0,0,0,0));
     margin: 0 @button-margin-size + 3;
   }


### PR DESCRIPTION
With dark themes, such as the One Dark UI, the separators are virtually invisible. These values I used seem to work well with both dark and light UI's.