### PR TITLE
fix: add `md-` prefix to regular ion icons

### DIFF
--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -44,7 +44,7 @@ module.exports = class ToolBarButtonView {
       if (options.iconset) {
         if (options.iconset.startsWith('fa')) {
           classNames.push(options.iconset, `fa-${options.icon}`);
-        } else if (options.iconset === 'ion' && !options.icon.startsWith('ios-') && !options.icon.startsWith('md-')) {
+        } else if (options.iconset === 'ion' && !options.icon.startsWith('ios-') && !options.icon.startsWith('md-') && !options.icon.startsWith('logo-')) {
           classNames.push(options.iconset, `${options.iconset}-md-${options.icon}`);
         } else {
           classNames.push(options.iconset, `${options.iconset}-${options.icon}`);

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -44,6 +44,8 @@ module.exports = class ToolBarButtonView {
       if (options.iconset) {
         if (options.iconset.startsWith('fa')) {
           classNames.push(options.iconset, `fa-${options.icon}`);
+        } else if (options.iconset === 'ion' && !options.icon.startsWith('ios-') && !options.icon.startsWith('md-')) {
+          classNames.push(options.iconset, `${options.iconset}-md-${options.icon}`);
         } else {
           classNames.push(options.iconset, `${options.iconset}-${options.icon}`);
         }

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -169,6 +169,18 @@ describe('Tool Bar package', () => {
         expect(getGlyph(toolBar.firstChild)).toBe('f150');
       });
 
+      it('prefix Ionicons with md-', () => {
+        jasmine.attachToDOM(toolBar);
+        toolBarAPI.addButton({
+          icon: 'refresh',
+          callback: 'application:about',
+          iconset: 'ion'
+        });
+        expect(toolBar.firstChild.classList.contains('ion')).toBe(true);
+        expect(toolBar.firstChild.classList.contains('ion-md-refresh')).toBe(true);
+        expect(getGlyph(toolBar.firstChild)).toBe('f366');
+      });
+
       it('using Font Awesome iconset', () => {
         jasmine.attachToDOM(toolBar);
         toolBarAPI.addButton({


### PR DESCRIPTION
prefixes ion icon with `md-` when no prefix is specified

fixes #264 
