### PR TITLE
Allowing more iconsizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ On which edge of the editor should the tool bar appear. Possible options:
 
 ### Icon size
 
-*   Very Small *(12px)*
-*   Small *(16px)*
+*   Tiny *(12px)*
+*   Very Small *(16px)*
+*   Small: *(18px)*
+*   Medium: *(21px)*
 *   Big *(24px)*
-*   Large *(32px)*
+*   Very Big *(28px)*
+*   Huge *(32px)*
 
 ### Visibility
 

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -4,11 +4,6 @@ const rafDebounce = require('./raf-debounce');
 module.exports = class ToolBarView {
 
   constructor () {
-    // warning for Atom-Material-UI
-    if (atom.themes.getEnabledThemeNames()[1] === 'atom-material-ui') {
-      atom.notifications.addWarning('Using "Atom-Material-UI" theme with "Tool-Bar" is not recommended. Use other themes such as "One-Datk-UI".');
-    };
-
     this.element = document.createElement('div');
     this.element.classList.add('tool-bar');
     this.items = [];

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -128,7 +128,10 @@ module.exports = class ToolBarView {
     this.element.classList.remove(
       'tool-bar-12px',
       'tool-bar-16px',
+      'tool-bar-18px',
+      'tool-bar-21px',
       'tool-bar-24px',
+      'tool-bar-28px',
       'tool-bar-32px'
     );
     this.element.classList.add(`tool-bar-${size}`);

--- a/lib/tool-bar-view.js
+++ b/lib/tool-bar-view.js
@@ -4,6 +4,11 @@ const rafDebounce = require('./raf-debounce');
 module.exports = class ToolBarView {
 
   constructor () {
+    // warning for Atom-Material-UI
+    if (atom.themes.getEnabledThemeNames()[1] === 'atom-material-ui') {
+      atom.notifications.addWarning('Using "Atom-Material-UI" theme with "Tool-Bar" is not recommended. Use other themes such as "One-Datk-UI".');
+    };
+
     this.element = document.createElement('div');
     this.element.classList.add('tool-bar');
     this.items = [];

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -30,7 +30,7 @@ exports.config = {
   iconSize: {
     type: 'string',
     default: '24px',
-    enum: ['12px', '16px', '24px', '32px'],
+    enum: ['12px', '16px', '18px', '21px', '24px', '28px', '32px'],
     order: 2
   },
   position: {

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -29,7 +29,7 @@ exports.config = {
   },
   iconSize: {
     type: 'string',
-    default: '24px',
+    default: '21px',
     enum: ['12px', '16px', '18px', '21px', '24px', '28px', '32px'],
     order: 2
   },

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -29,7 +29,7 @@ exports.config = {
   },
   iconSize: {
     type: 'string',
-    default: '21px',
+    default: '24px',
     enum: ['12px', '16px', '18px', '21px', '24px', '28px', '32px'],
     order: 2
   },

--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -90,8 +90,17 @@
   &.tool-bar-16px {
     .tool-bar-size(16px * 2);
   }
+  &.tool-bar-18px {
+    .tool-bar-size(18px * 2);
+  }
+  &.tool-bar-21px {
+    .tool-bar-size(21px * 2);
+  }
   &.tool-bar-24px {
     .tool-bar-size(24px * 2);
+  }
+  &.tool-bar-28px {
+    .tool-bar-size(28px * 2);
   }
   &.tool-bar-32px {
     .tool-bar-size(32px * 2);


### PR DESCRIPTION
- Adds icons size of 18,21,28
- Setting default size to 21

Derived from https://github.com/suda/tool-bar/pull/218