### PR TITLE
Add activationHook

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
         "1.0.0": "provideToolBar"
       }
     }
-  }
+  },
+  "activationHooks": [
+    "core:loaded-shell-environment"
+  ]
 }

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -36,6 +36,9 @@ describe('Tool Bar package', () => {
       const pack = await atom.packages.activatePackage('tool-bar');
       toolBarService = pack.mainModule.provideToolBar();
     });
+
+    atom.packages.triggerDeferredActivationHooks();
+    atom.packages.triggerActivationHook('core:loaded-shell-environment');
   });
 
   describe('@activate', () => {


### PR DESCRIPTION
As mentioned in the Atom documentation, `activationHooks` (or `activationCommands`) will improve startup performance by deferring the package activation. Since this package is grammar agnostic, the `core:loaded-shell-environment` hook is the only suitable one.