### PR TITLE
Add any class to a toolbar button

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ export function consumeToolBar(getToolBar) {
     background: 'black' // color of the background
   });
 
-  // Buttons can be styled with arbitrary CSS through classes
+  // Buttons can be styled with arbitrary CSS through classes.
+  // An example of how the class can be used is show below.
   toolBar.addButton({
     icon: 'octoface',
     callback: 'application:about',
@@ -224,6 +225,19 @@ export function consumeToolBar(getToolBar) {
     this.toolBar = null;
     // Teardown any stateful code that depends on tool bar ...
   });
+}
+```
+
+```css
+/*
+Follow the instructions at:
+https://flight-manual.atom.io/using-atom/sections/basic-customization/#style-tweaks
+to define your classes.
+*/
+.my-awesome-class {
+  background-image: url(data:image/svg+xml;base64,...);
+  background-repeat: no-repeat;
+  background-position: center;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ export function consumeToolBar(getToolBar) {
     background: 'black' // color of the background
   });
 
+  // Buttons can be styled with arbitrary CSS through classes
+  toolBar.addButton({
+    icon: 'octoface',
+    callback: 'application:about',
+    class: 'my-awesome-class'
+  });
+  toolBar.addButton({
+    icon: 'octoface',
+    callback: 'application:about',
+    class: ['multiple', 'classes', 'also', 'works']
+  });
+
   // Cleaning up when tool bar is deactivated
   toolBar.onDidDestroy(() => {
     this.toolBar = null;
@@ -232,8 +244,9 @@ The remaining properties
 `iconset` (defaults to `Octicons`),
 `data`,
 `priority` (defaults `50`),
-`color`, and
-`background`
+`color`,
+`background`, and
+`class`
 are optional.
 
 The `tooltip` option may be a `string` or an `object` that is passed to Atom's

--- a/lib/tool-bar-button-view.js
+++ b/lib/tool-bar-button-view.js
@@ -67,6 +67,14 @@ module.exports = class ToolBarButtonView {
       this.element.style.background = options.background;
     }
 
+    if (options.class) {
+      if (Array.isArray(options.class)) {
+        this.element.classList.add(...options.class);
+      } else {
+        this.element.classList.add(options.class);
+      }
+    }
+
     this.element.classList.add(...classNames);
 
     this._onMouseDown = this._onMouseDown.bind(this);

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -150,6 +150,29 @@ describe('Tool Bar package', () => {
         expect(element.outerHTML.indexOf('<span>text</span>')).not.toBe(-1);
       });
 
+      it('with one class', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about',
+          class: 'class'
+        });
+        expect(toolBar.children.length).toBe(1);
+        const element = toolBar.firstChild;
+        expect(element.classList.contains('class')).toBe(true);
+      });
+
+      it('with multiple classes', () => {
+        toolBarAPI.addButton({
+          icon: 'octoface',
+          callback: 'application:about',
+          class: ['class-a', 'class-b']
+        });
+        expect(toolBar.children.length).toBe(1);
+        const element = toolBar.firstChild;
+        expect(element.classList.contains('class-a')).toBe(true);
+        expect(element.classList.contains('class-b')).toBe(true);
+      });
+
       it('using default iconset', () => {
         jasmine.attachToDOM(toolBar);
         toolBarAPI.addButton({


### PR DESCRIPTION
Closes #271, this would allow users to add any class(es) to buttons. They can then define the class in a local stylesheet an customize buttons as they see fit.

They can do this through the `class` option which can be either a string or an array of strings. If it is an array every string will be added separately.

~~Arguably this is unnecessary as you can add multiple strings simply by putting spaces in the string.~~ This is not possible with the current implementation, but an be implemented instead if desired.

Example usage:

```js
  toolBar.addButton({
    icon: 'octoface',
    callback: 'application:about',
    class: 'my-awesome-class'
  });

  toolBar.addButton({
    icon: 'octoface',
    callback: 'application:about',
    class: ['multiple', 'classes', 'also', 'works']
  });
```