### PR TITLE
Remove unmaintained plugins and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ currently) it can display up to seven tool bar buttons there.
 ## Packages using tool-bar
 
 *   [Particle Dev](https://atom.io/packages/spark-dev)
-*   [Facebook Nuclide](https://atom.io/packages/nuclide)
 *   [PlatformIO IDE](https://atom.io/packages/platformio-ide)
 *   [Organized](https://atom.io/packages/organized)
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ currently) it can display up to seven tool bar buttons there.
 
 *   [Flex Tool Bar](https://atom.io/packages/flex-tool-bar)
 *   [Tool Bar Main](https://atom.io/packages/tool-bar-main)
-*   [Toolbar Almighty](https://atom.io/packages/tool-bar-almighty)
 *   [Toolbar for Atom](https://atom.io/packages/tool-bar-atom)
-*   [Toolbar Shortcuts](https://atom.io/packages/tool-bar-shortcuts)
 *   And [more](https://atom.io/packages/search?utf8=%E2%9C%93&q=keyword%3Atool-bar)...
 
 ## Packages using tool-bar


### PR DESCRIPTION
Inspired by #286, this updates the list of plugins and packages using this toolbar:

- Toolbar Almighty: [the repo](https://github.com/varemenos/atom-toolbar-almighty) has been archived by it's owner and will not therefore not receive any updates in the future.
- Toolbar Shortcuts: [the repo](https://github.com/JostCrow/atom-toolbar-shortcuts) has been archived by it's owner and will not therefore not receive any updates in the future.
- Facebook Nuclide: [the package](https://atom.io/packages/nuclide) has been removed (that links returns a 404).