### PR TITLE
Type declarations for TypeScript

### DIFF
--- a/@types/config.d.ts
+++ b/@types/config.d.ts
@@ -1,0 +1,27 @@
+import "../index"
+
+declare module "atom" {
+    interface ConfigValues {
+        /** Make tool-bar visible. - default: true */
+        "tool-bar.visible": boolean
+
+        /** Icon size. - default: "24px" */
+        "tool-bar.iconSize":
+            | "12px"
+            | "16px"
+            | "18px"
+            | "21px"
+            | "24px"
+            | "28px"
+            | "32px"
+
+        /** Position of tool-bar. - default: "Top"  */
+        "tool-bar.position": "Top" | "Right" | "Bottom" | "Left"
+
+        /** Fit the tool-bar to the window's full-width. - default: true */
+        "tool-bar.fullWidth": boolean
+
+        /** On MacOS, show seven first tool-bar buttons in the TouchBar. - default: true */
+        "tool-bar.useTouchBar": string
+    }
+}

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -153,3 +153,26 @@ export declare class ToolBarManager {
     /** The onDidDestroy method takes a function that will be called when the tool-bar package is destroyed. This is useful if your package needs to do cleanup when the tool-bar is deactivated but your package continues running. */
     onDidDestroy(callback: () => void): void
 }
+
+/**
+ *  Passed as an input to `consumeToolBar(getToolBar: getToolbarCallback)` function of your package.
+ *
+ *  In your main package file, add the following methods and replace your-package-name with your package name.
+ * ```js
+ *  let toolBar: ToolBarManager
+ *
+ *  export function consumeToolBar(getToolBar: getToolbarCallback) {
+ *   toolBar = getToolBar("packageName");
+ *   // Add buttons and spacers here...
+ * }
+ *
+ *
+ *  export function deactivate() {
+ *   if (toolBar) {
+ *     toolBar.removeItems();
+ *     toolBar = null;
+ *   }
+ * }
+ *  ```
+ */
+export type getToolbarCallback = (packageName: string) => ToolBarManager

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -154,10 +154,12 @@ export declare class ToolBarManager {
     /** Adds a spacer. Optionally, you can pass a `SpacerOptions` object */
     addSpacer(options?: SpacerOptions): void
 
-    /** Use the method removeItems to remove the buttons added by your package. This is particular useful in your package deactivate method, but can be used at any time. */
+    /** Use the method removeItems to remove the buttons added by your package. This is particular useful in your package deactivate method, but can be used at any time.
+     */
     removeItems(): void
 
-    /** The onDidDestroy method takes a function that will be called when the tool-bar package is destroyed. This is useful if your package needs to do cleanup when the tool-bar is deactivated but your package continues running. */
+    /** The onDidDestroy method takes a function that will be called when the tool-bar package is destroyed. This is useful if your package needs to do cleanup when the tool-bar is deactivated but your package continues running.
+     */
     onDidDestroy(callback: () => void): void
 }
 

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -140,3 +140,16 @@ export declare interface SpacerOptions {
     priority?: number
 }
 
+export declare class ToolBarManager {
+    /** Adds a button. The input to this function is a `ButtonOptions` object */
+    addButton(options: ButtonOptions): void
+
+    /** Adds a spacer. Optionally, you can pass a `SpacerOptions` object */
+    addSpacer(options?: SpacerOptions): void
+
+    /** Use the method removeItems to remove the buttons added by your package. This is particular useful in your package deactivate method, but can be used at any time. */
+    removeItems(): void
+
+    /** The onDidDestroy method takes a function that will be called when the tool-bar package is destroyed. This is useful if your package needs to do cleanup when the tool-bar is deactivated but your package continues running. */
+    onDidDestroy(callback: () => void): void
+}

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -134,3 +134,9 @@ export declare interface ButtonOptions {
      */
     class?: string | Array<string>
 }
+
+export declare interface SpacerOptions {
+    /** (optional) defaults to `50` */
+    priority?: number
+}
+

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,3 +1,8 @@
+// tool-bar 1.2.x
+// https://atom.io/packages/tool-bar
+
+/// <reference path="./config.d.ts" />
+
 export declare interface ButtonOptions {
     /** (optional)
      *  icon name

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,0 +1,136 @@
+export declare interface ButtonOptions {
+    /** (optional)
+     *  icon name
+     * ## Example:
+     * ```js
+     * icon: 'octoface',
+     * ```
+     */
+    icon?: string
+
+    /** (optional)
+     * icon set name.
+     * It can be chosen among these:
+     *    - not given : if `iconset` is not given Octicons (default Atom's flavour) is chosen
+     *    - `ion` with `ios-` and `md- `prefixes for the icon names (Ionicons)
+     *    - `fa` and fab for brands (FontAwesome)
+     *    - `fi` (Foundation)
+     *    - `icomoon` (IcoMoon)
+     *    - `devicon` (Devicon)
+     *    - `mdi` (MaterialDesignIcons)
+     *
+     * ## Example:
+     * ```js
+     *     icon: 'ios-gear-a',
+     *     iconset: 'ion'
+     * ```
+     */
+    iconset?:
+        | undefined
+        | "ion"
+        | "fa"
+        | "fab"
+        | "fi"
+        | "icomoon"
+        | "devicon"
+        | "mdi"
+
+    /** (optional)
+     * You can use `text` to:
+     * - add text as a button, or
+     *
+     * ## Example:
+     * ```js
+     * text: 'hello',
+     * ```
+     * - use HTML for a button. Needs `html` to be set to `true`
+     *
+     * ## Example:
+     * ```
+     * text: '<b>BIG</b> button',
+     * html: true,
+     * ```
+     */
+    text?: string
+
+    /** (optional)
+     * if set to `true`, `text` will be rendered as HTML
+     * ## Example:
+     * ```js
+     * text: '<b>BIG</b> button',
+     * html: true,
+     * ```
+     */
+    html?: boolean
+
+    /** (mandatory)
+
+     * The callback must be either:
+     * - Atom command: a string or array of  strings,
+     * - a custom callback function,
+     * - or an object where the keys are key modifiers (alt, ctrl or shift) and the values are commands or custom functions
+     *
+     * ## Example:
+     * ```js
+     * callback: 'application:about',
+     * ```
+     *
+     *
+     * ## Example - Callback with modifiers
+     * ```js
+     * callback: {
+     *    '': 'application:cmd-1',      // Without modifiers is default action
+     *    'alt': 'application:cmd-2',
+     *    'ctrl': 'application:cmd-3',  // With function callback
+     *    'shift'(data) {
+     *      console.log(data);
+     *    },
+     *    'alt+shift': 'application:cmd-5',       // Multiple modifiers
+     *    'alt+ctrl+shift': 'application:cmd-6'   // All modifiers
+     *  },
+     * data: 'foo'
+     * ```
+     */
+    callback:
+        | string
+        | Array<string>
+        | ((data?: any) => void)
+        | { [modifier: string]: string }
+        | { [modifier: string]: (data?: any) => void }
+
+    /** `data` can be passed as the input argument of callback,  If callback is of type
+     * - `(data: any) => void)` or
+     * - `{ [modifier: string]: ((data: any) => void) }`,
+     *
+     */
+    data?: any
+
+    /** (optional) defaults to `50` */
+    priority?: number
+
+    /** (optional)
+     * The tooltip option may be a string or an object that is passed to Atom's TooltipManager
+     */
+    tooltip?: string | object
+
+    /** (optional) Color of the button */
+    color?: string
+
+    /** (optional) Color of the button's background */
+    background?: string
+
+    /** Buttons can be styled with arbitrary CSS through classes.
+     * An example of how the class can be used is show below.
+     *
+     * ## Example:
+     * ```js
+     * class: 'my-awesome-class'
+     * ```
+     *
+     * ## Example:
+     * ```js
+     * class: ['multiple', 'classes', 'also', 'works']
+     * ```
+     */
+    class?: string | Array<string>
+}

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -3,6 +3,8 @@
 
 /// <reference path="./config.d.ts" />
 
+import { TooltipManager } from "../index"
+
 export declare interface ButtonOptions {
     /** (optional)
      *  icon name
@@ -25,7 +27,7 @@ export declare interface ButtonOptions {
      *    - `mdi` (MaterialDesignIcons)
      *
      * ## Example:
-     * ```js
+     * ```ts
      *     icon: 'ios-gear-a',
      *     iconset: 'ion'
      * ```
@@ -45,13 +47,13 @@ export declare interface ButtonOptions {
      * - add text as a button, or
      *
      * ## Example:
-     * ```js
+     * ```ts
      * text: 'hello',
      * ```
      * - use HTML for a button. Needs `html` to be set to `true`
      *
      * ## Example:
-     * ```
+     * ```ts
      * text: '<b>BIG</b> button',
      * html: true,
      * ```
@@ -61,7 +63,7 @@ export declare interface ButtonOptions {
     /** (optional)
      * if set to `true`, `text` will be rendered as HTML
      * ## Example:
-     * ```js
+     * ```ts
      * text: '<b>BIG</b> button',
      * html: true,
      * ```
@@ -76,13 +78,13 @@ export declare interface ButtonOptions {
      * - or an object where the keys are key modifiers (alt, ctrl or shift) and the values are commands or custom functions
      *
      * ## Example:
-     * ```js
+     * ```ts
      * callback: 'application:about',
      * ```
      *
      *
      * ## Example - Callback with modifiers
-     * ```js
+     * ```ts
      * callback: {
      *    '': 'application:cmd-1',      // Without modifiers is default action
      *    'alt': 'application:cmd-2',
@@ -116,7 +118,7 @@ export declare interface ButtonOptions {
     /** (optional)
      * The tooltip option may be a string or an object that is passed to Atom's TooltipManager
      */
-    tooltip?: string | object
+    tooltip?: string | TooltipManager
 
     /** (optional) Color of the button */
     color?: string
@@ -128,12 +130,12 @@ export declare interface ButtonOptions {
      * An example of how the class can be used is show below.
      *
      * ## Example:
-     * ```js
+     * ```ts
      * class: 'my-awesome-class'
      * ```
      *
      * ## Example:
-     * ```js
+     * ```ts
      * class: ['multiple', 'classes', 'also', 'works']
      * ```
      */
@@ -163,7 +165,7 @@ export declare class ToolBarManager {
  *  Passed as an input to `consumeToolBar(getToolBar: getToolbarCallback)` function of your package.
  *
  *  In your main package file, add the following methods and replace your-package-name with your package name.
- * ```js
+ * ```ts
  *  let toolBar: ToolBarManager
  *
  *  export function consumeToolBar(getToolBar: getToolbarCallback) {
@@ -178,6 +180,6 @@ export declare class ToolBarManager {
  *     toolBar = null;
  *   }
  * }
- *  ```
+ * ```
  */
 export type getToolbarCallback = (packageName: string) => ToolBarManager


### PR DESCRIPTION
This adds types for tool-bar public API. 

However, since this package is not an `npm` package, we should either push this to [@types/atom](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/atom)
or make a separate `@types/tool-bar`. 

I prefer the first option, `../index` is refering to that file.

Either way, it is good to keep a copy of that file here.


See this in action here: https://github.com/aminya/juno-plus