### PR TITLE
Less compiling solution

### DIFF
--- a/styles/tool-bar.less
+++ b/styles/tool-bar.less
@@ -38,6 +38,7 @@
     }
   }
 
+  // Set the margin between the buttons (that are not at the end)
   &.tool-bar-horizontal .tool-bar-btn:not(.tool-bar-item-align-end) + .tool-bar-btn {
     margin-left: 0;
   }
@@ -61,8 +62,7 @@
   }
 
   &.tool-bar-horizontal {
-    .tool-bar-btn,
-    .tool-bar-spacer {
+    .tool-bar-btn, .tool-bar-spacer {
       &.tool-bar-item-align-end {
         order: 2;
         &:first-child {
@@ -73,8 +73,7 @@
   }
 
   &.tool-bar-vertical {
-    .tool-bar-btn,
-    .tool-bar-spacer {
+    .tool-bar-btn, .tool-bar-spacer {
       &.tool-bar-item-align-end {
         order: 2;
         &:first-child {

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -1,0 +1,85 @@
+// This file has fallback variables. It specifies the variables themes
+// must implement.
+
+// Colors
+
+@text-color: #333;
+@text-color-subtle: #777;
+@text-color-highlight: #111;
+@text-color-selected: @text-color-highlight;
+
+@text-color-info: #5293d8;
+@text-color-success: #1fe977;
+@text-color-warning: #f78a46;
+@text-color-error: #c00;
+
+@background-color-info: #0098ff;
+@background-color-success: #17ca65;
+@background-color-warning: #ff4800;
+@background-color-error: #c00;
+@background-color-highlight: hsla(0,0%,0%,.1);
+@background-color-selected: @background-color-highlight;
+
+@app-background-color: #fff;
+
+@base-background-color: #fff;
+@base-border-color: #eee;
+
+@pane-item-background-color: @base-background-color;
+@pane-item-border-color: @base-border-color;
+
+@input-background-color: #fff;
+@input-border-color: @base-border-color;
+
+@tool-panel-background-color: #f4f4f4;
+@tool-panel-border-color: @base-border-color;
+
+@inset-panel-background-color: #eee;
+@inset-panel-border-color: @base-border-color;
+
+@panel-heading-background-color: #ddd;
+@panel-heading-border-color: transparent;
+
+@overlay-background-color: #f4f4f4;
+@overlay-border-color: @base-border-color;
+
+@button-background-color: #ccc;
+@button-background-color-hover: lighten(@button-background-color, 5%);
+@button-background-color-selected: @button-background-color-hover;
+@button-border-color: #aaa;
+
+@tab-bar-background-color: #fff;
+@tab-bar-border-color: darken(@tab-background-color-active, 10%);
+@tab-background-color: #f4f4f4;
+@tab-background-color-active: #fff;
+@tab-border-color: @base-border-color;
+
+@tree-view-background-color: @tool-panel-background-color;
+@tree-view-border-color: @tool-panel-border-color;
+
+@ui-site-color-1: @background-color-success; // green
+@ui-site-color-2: @background-color-info; // blue
+@ui-site-color-3: @background-color-warning; // orange
+@ui-site-color-4: #db2ff4; // purple
+@ui-site-color-5: #f5e11d; // yellow
+
+
+// Sizes
+
+@font-size: 13px;
+@input-font-size: 14px;
+
+@disclosure-arrow-size: 12px;
+
+@component-padding: 10px;
+@component-icon-padding: 5px;
+@component-icon-size: 16px;
+@component-line-height: 25px;
+@component-border-radius: 2px;
+
+@tab-height: 30px;
+
+// Other
+
+@font-family: system-ui;
+@use-custom-controls: true; // false uses native controls


### PR DESCRIPTION
Solves the less compiling problem.

Fixes how spacers look like:
![image](https://user-images.githubusercontent.com/16418197/80150017-3c761800-857d-11ea-8f89-131c5caaccec.png)

Compared to now color for spacers before this:
![](https://user-images.githubusercontent.com/16418197/76567589-1ab54b80-647d-11ea-8914-525c36161d4c.png)