### PR TITLE
Remove activation hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
         "1.0.0": "provideToolBar"
       }
     }
-  },
-  "activationHooks": [
-    "core:loaded-shell-environment"
-  ]
+  }
 }

--- a/spec/tool-bar-spec.js
+++ b/spec/tool-bar-spec.js
@@ -34,8 +34,9 @@ describe('Tool Bar package', () => {
       toolBarService = pack.mainModule.provideToolBar();
     });
 
-    atom.packages.triggerDeferredActivationHooks();
-    atom.packages.triggerActivationHook('core:loaded-shell-environment');
+    // if activation hook was being used
+    // atom.packages.triggerDeferredActivationHooks();
+    // atom.packages.triggerActivationHook('core:loaded-shell-environment');
   });
 
   describe('@activate', () => {


### PR DESCRIPTION
Tool-bar late loading does not look good. It makes the Atom look bulky. I think 20ms is not that long to defer it.