### PR TITLE
Update to current TouchBar Electron API

### DIFF
--- a/lib/touch-bar-manager.js
+++ b/lib/touch-bar-manager.js
@@ -76,7 +76,7 @@ export class TouchBarManager {
     const items = this.buttons
       .sort((a, b) => a.priority - b.priority)
       .map(button => button.touchButton);
-    let touchBar = new TouchBar(items);
+    let touchBar = new TouchBar({items});
     atom.getCurrentWindow().setTouchBar(touchBar);
     this._updateDebounce = null;
   }


### PR DESCRIPTION
On my installation, the touch bar didn't originally work. After looking at the Electron documentation, I noticed that the TouchBar API is still experimental. Comparing the code of this library to a working example, I have determined that the fix is to wrap 'items' within an object when it is passed to the TouchBar constructor. This PR contains that change.