### PR TITLE
fix deactivate

### DIFF
--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -20,14 +20,10 @@ async function useTouchBar() {
 }
 
 export function deactivate() {
-  if (toolBarView) {
-    toolBarView.destroy();
-    toolBarView = null;
-  }
-  if (touchBarManager) {
-    touchBarManager.destroy();
-    touchBarManager = null;
-  }
+  toolBarView?.destroy();
+  toolBarView = null;
+  touchBarManager?.destroy();
+  touchBarManager = null;
 }
 
 export function provideToolBar () {

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -24,7 +24,7 @@ export function deactivate() {
     toolBarView.destroy();
     toolBarView = null;
   }
-  if (toolBarManager) {
+  if (touchBarManager) {
     touchBarManager.destroy();
     touchBarManager = null;
   }

--- a/lib/tool-bar.js
+++ b/lib/tool-bar.js
@@ -20,10 +20,14 @@ async function useTouchBar() {
 }
 
 export function deactivate() {
-  toolBarView.destroy();
-  toolBarView = null;
-  touchBarManager.destroy();
-  touchBarManager = null;
+  if (toolBarView) {
+    toolBarView.destroy();
+    toolBarView = null;
+  }
+  if (toolBarManager) {
+    touchBarManager.destroy();
+    touchBarManager = null;
+  }
 }
 
 export function provideToolBar () {


### PR DESCRIPTION
deactivate throw the following error on windows.

```
Error deactivating package 'tool-bar' TypeError: Cannot read property 'destroy' of null
```